### PR TITLE
Decouple EdgeProcessor from data to be loaded

### DIFF
--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -58,3 +58,24 @@ JobId in history server: 594f9a37-08ab-4400-a8fa-e9990dc90d3b-0225
 |---------------|------------|------------------------|----------------------|--------------------|----------------|----------------|-------------------|
 |107619|128480018|100|500|12 s|47 min|55 min|1 failure in edgeLoader, 6 failures in counting edges|
 
+### 4
+
+Environment details
+
+HBase
+Similarity value Dataype Int
+But we use DataFrame instead of Dataset[EdgeClass]
+Spark cluster running over mesos
+
+| # of executors | Executor memory | Executor cores | Driver memory |
+|----------------|-----------------|----------------|---------------|
+|50|2g|2|2g
+
+Run details
+
+JobId in history server: 594f9a37-08ab-4400-a8fa-e9990dc90d3b-0302
+
+| # of vertices | # of edges | vertexLoader batchsize | edgeLoader batchsize |  Vertex load time  | Edge load time | Total Job time | # of tasks failed |
+|---------------|------------|------------------------|----------------------|--------------------|----------------|----------------|-------------------|
+|107619|128480018|100|500|10 s|47 min|56 min|0|
+

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -25,6 +25,7 @@ object BuildHelper {
   val fastParseVersion = "2.1.0"
   val zioLoggingVersion = "0.3.0"
   val sparkVersion = "2.4.4"
+  val sparkDariaVersion = "v0.35.0"
   val scoptVersion = "3.7.1"
   val hbaseVersion = "2.0.5"
   val janusGraphVersion = "0.5.1"
@@ -54,7 +55,9 @@ object BuildHelper {
 
   lazy val basicSettings = Seq(
     resolvers ++= Seq(
-      "central" at "https://repo1.maven.org/maven2/"
+      "central" at "https://repo1.maven.org/maven2/",
+      // For spark daria
+      "jitpack" at "https://jitpack.io"
     )
   ) ++ testSettings
 
@@ -79,6 +82,7 @@ object BuildHelper {
         ),
         "org.apache.spark" %% "spark-core" % sparkVersion,
         "org.apache.spark" %% "spark-sql" % sparkVersion,
+        "com.github.mrpowers" % "spark-daria" % sparkDariaVersion,
         "org.janusgraph" % "janusgraph-core" % janusGraphVersion,
         "org.janusgraph" % "janusgraph-hbase" % janusGraphVersion,
         "org.janusgraph" % "janusgraph-inmemory" % janusGraphVersion

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -46,7 +46,7 @@ object BuildHelper {
     // Fail the test suite if statement coverage is < 70%
     coverageFailOnMinimum := true,
     // TODO: Increase this to 70+
-    coverageMinimum := 44,
+    coverageMinimum := 60,
     // Put nice colors on the coverage report
     coverageHighlighting := true,
     // Do not publish artifact in test

--- a/src/main/scala/com/astrolabsoftware/grafink/processor/edgerules/VertexClassifierRule.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/processor/edgerules/VertexClassifierRule.scala
@@ -18,20 +18,22 @@ package com.astrolabsoftware.grafink.processor.edgerules
 
 import org.apache.spark.sql.{ DataFrame, Dataset }
 
-import com.astrolabsoftware.grafink.processor.EdgeProcessor.MakeEdge
-
 trait VertexClassifierRule {
 
   def name: String
 
   /**
    * Given data already existing in graph (loadedDf) and the new data to ingest (df)
-   * Return a Dataset of {@link MakeEdge}. In all the rows of the returned RDD, src id
+   * Return a DataFrame of Edge rows. In all the rows of the returned DataFrame, src id
    * must always be of the new data to ingest (df).
+   * The contract mandates the returned DataFrame to have the requiredEdgeColumns as defined
+   * in the EdgeProcessor.
    * @param df
    * @return DataFrame
    */
-  def classify(loadedDf: DataFrame, df: DataFrame): Dataset[MakeEdge]
+  def classify(loadedDf: DataFrame, df: DataFrame): DataFrame
 
   def getEdgeLabel: String
+
+  def getEdgePropertyKey: String
 }

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/edgerules/SimilarityClassifierSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/edgerules/SimilarityClassifierSpec.scala
@@ -1,10 +1,10 @@
 package com.astrolabsoftware.grafink.processor.edgerules
 
+import org.apache.spark.sql.Row
 import zio.test._
 import zio.test.Assertion.hasSameElementsDistinct
 
 import com.astrolabsoftware.grafink.models._
-import com.astrolabsoftware.grafink.processor.EdgeProcessor.MakeEdge
 import com.astrolabsoftware.grafink.utils.SparkTestEnv
 
 object SimilarityClassifierSpec extends DefaultRunnableSpec {
@@ -92,7 +92,7 @@ object SimilarityClassifierSpec extends DefaultRunnableSpec {
           similarityClassifer.classify(loadedDf, currentDf).collect.toList
         }
 
-        assertM(app.provideLayer(sparkLayer))(hasSameElementsDistinct(List(MakeEdge(2L, 1L, 1))))
+        assertM(app.provideLayer(sparkLayer))(hasSameElementsDistinct(List(Row(2L, 1L, 1))))
       },
       testM("Similarity classifier will correctly make an edge between new vertices") {
 
@@ -152,7 +152,7 @@ object SimilarityClassifierSpec extends DefaultRunnableSpec {
           similarityClassifer.classify(loadedDf, currentDf).collect.toList
         }
 
-        assertM(app.provideLayer(sparkLayer))(hasSameElementsDistinct(List(MakeEdge(2L, 1L, 1))))
+        assertM(app.provideLayer(sparkLayer))(hasSameElementsDistinct(List(Row(2L, 1L, 1))))
       },
       testM("Similarity classifier will correctly calculate similarity") {
 
@@ -203,7 +203,7 @@ object SimilarityClassifierSpec extends DefaultRunnableSpec {
           similarityClassifer.classify(loadedDf, currentDf).collect.toList
         }
 
-        assertM(app.provideLayer(sparkLayer))(hasSameElementsDistinct(List(MakeEdge(2L, 1L, 5))))
+        assertM(app.provideLayer(sparkLayer))(hasSameElementsDistinct(List(Row(2L, 1L, 5))))
       }
     )
 }


### PR DESCRIPTION
This PR addresses #12 , where we strive to generalize grafink, so that the data model and schema (data specific changes) are limited to the VertexClassifier rules.
This is a step in the direction of making grafink more general for loading any data into JanusGraph