### PR TITLE
Add support for data deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ idManager {
   spark {
     // The base path where data will be generated. Note that partitioning of the original data is maintained
     dataPath = "/test/intermediate/base/path"
+    // Whether to clear IDManager data when running grafink in delete mode to delete data from JanusGraph
+    clearOnDelete = false
   }
   // This configuration is used by IDManager backed by HBase
   hbase {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,7 +15,7 @@ reader {
 idManager {
   spark {
     dataPath = "/test/intermediate/base/path"
-    clearDataOnDelete = false
+    clearOnDelete = false
   }
   hbase {
     tableName = "IDManagement"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,6 +15,7 @@ reader {
 idManager {
   spark {
     dataPath = "/test/intermediate/base/path"
+    clearDataOnDelete = false
   }
   hbase {
     tableName = "IDManagement"

--- a/src/main/scala/com/astrolabsoftware/grafink/Boot.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/Boot.scala
@@ -69,18 +69,18 @@ object Boot extends App {
         val vertexProcessorLayer = logger ++ configLayer >>> VertexProcessor.live
         val edgeProcessorLayer   = logger ++ configLayer >>> EdgeProcessor.live
 
-        Job
-          .runGrafinkJob(JobTime(argsConfig.startDate, argsConfig.duration))
-          .provideCustomLayer(
-            SparkEnv.cluster ++
-              configLayer ++
-              schemaLoaderLayer ++
-              readerLayer ++
-              idManagerLayer ++
-              vertexProcessorLayer ++
-              edgeProcessorLayer ++
-              logger
-          )
+        val jobTime = JobTime(argsConfig.startDate, argsConfig.duration)
+        val job     = if (argsConfig.deleteMode) Job.runGrafinkDeleteJob(jobTime) else Job.runGrafinkJob(jobTime)
+        job.provideCustomLayer(
+          SparkEnv.cluster ++
+            configLayer ++
+            schemaLoaderLayer ++
+            readerLayer ++
+            idManagerLayer ++
+            vertexProcessorLayer ++
+            edgeProcessorLayer ++
+            logger
+        )
       case None =>
         ZIO.fail(BadArgumentsException("Invalid command line arguments"))
     }

--- a/src/main/scala/com/astrolabsoftware/grafink/CLParser.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/CLParser.scala
@@ -24,7 +24,7 @@ import scopt.OptionParser
 
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 
-final case class ArgsConfig(confFile: String, startDate: LocalDate, duration: Int)
+final case class ArgsConfig(confFile: String, startDate: LocalDate, duration: Int, deleteMode: Boolean = false)
 
 /**
  * Command line parser for Grafink
@@ -69,6 +69,14 @@ trait CLParser {
         .text(
           "duration accepts duration (# of days) for which the job needs to process the data starting from startdate"
         )
+
+      opt[Unit]('d', "delete")
+        .optional()
+        .action((_, c) => c.copy(deleteMode = true))
+        .text(
+          "delete flag will delete the data for the specified startdate and duration for which the data has been computed by IDManager"
+        )
+
     }
 
   def validateDate(date: String): Boolean = Try { getLocalDate(date); true }.getOrElse(false)

--- a/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
@@ -92,6 +92,6 @@ object JanusGraphEnv extends Serializable {
         .set("graph.set-vertex-id", true)
         .open()
 
-  def withGraph(config: JanusGraphConfig, use: JanusGraph => ZIO[Any, Throwable, Unit]): ZIO[Any, Throwable, Unit] =
+  def withGraph[R](config: JanusGraphConfig, use: JanusGraph => ZIO[R, Throwable, Unit]): ZIO[R, Throwable, Unit] =
     ZIO.effect(withHBaseStorageWithBulkLoad(config)).bracket(releaseGraph, use)
 }

--- a/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
@@ -25,10 +25,12 @@ import com.astrolabsoftware.grafink.models.JanusGraphConfig
 
 object JanusGraphEnv extends Serializable {
 
-  def releaseGraph: JanusGraph => zio.URIO[Any, ZIO[Logging, Nothing, Unit]] =
+  def releaseGraph: JanusGraph => zio.URIO[Any, Unit] =
     (graph: JanusGraph) =>
-      ZIO
-        .effect(graph.close())
+      (for {
+        _ <- ZIO.effect(graph.tx().commit())
+        _ <- ZIO.effect(graph.close())
+      } yield ())
         .fold(_ => log.error(s"Error closing janusgraph instance"), _ => log.info(s"JanusGraph instance closed"))
 
   def hbaseBasic(config: JanusGraphConfig): ZManaged[Logging, Throwable, JanusGraph] =

--- a/src/main/scala/com/astrolabsoftware/grafink/Job.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/Job.scala
@@ -20,9 +20,9 @@ import java.time.LocalDate
 
 import org.apache.spark.sql.DataFrame
 import zio._
-import zio.logging.Logging
+import zio.logging.{ log, Logging }
 
-import com.astrolabsoftware.grafink.common.PartitionManager
+import com.astrolabsoftware.grafink.common.{ PaddedPartitionManager, PartitionManagerImpl, Utils }
 import com.astrolabsoftware.grafink.models.config._
 import com.astrolabsoftware.grafink.processor.{ EdgeProcessor, VertexProcessor }
 import com.astrolabsoftware.grafink.processor.EdgeProcessor.EdgeProcessorService
@@ -63,9 +63,9 @@ object Job {
     jobTime =>
       for {
         janusGraphConfig <- Config.janusGraphConfig
-        partitionManager = PartitionManager(jobTime.day, jobTime.duration)
+        partitionManager = PaddedPartitionManager(jobTime.day, jobTime.duration)
         // read current data
-        df <- Reader.read(partitionManager)
+        df <- Reader.readAndProcess(partitionManager)
         _ <- JanusGraphEnv
           .hbaseBasic(janusGraphConfig)
           .use(graph =>
@@ -86,14 +86,33 @@ object Job {
         )
       } yield ()
 
-  /**
-   * Runs the spark job to load data into JanusGraph
-   */
-  val runGrafinkJob: JobTime => ZIO[RunEnv, Throwable, Unit] =
+  val delete: JobTime => ZIO[RunEnv, Throwable, Unit] =
     jobTime =>
       for {
+        janusGraphConfig <- Config.janusGraphConfig
+        idManagerConfig  <- Config.idManagerConfig
+        basePath         = s"${idManagerConfig.spark.dataPath}/${janusGraphConfig.storage.tableName}"
+        partitionManager = PartitionManagerImpl(jobTime.day, jobTime.duration)
+        // read data for the specified date from idmanager data path
+        df <- Reader.read(basePath, partitionManager)
+        // Delete vertices
+        _ <- VertexProcessor.delete(df)
+        _ <- if (idManagerConfig.spark.clearOnDelete) {
+          // Clear IdManagerData as well
+          Utils.withFileSystem(fs => partitionManager.deletePartitions(basePath, fs))(df.sparkSession)
+        } else {
+          log.info(s"Skipping deleting IDManager data")
+        }
+      } yield ()
+
+  /**
+   * Runs the spark job with specified job
+   */
+  val runJob: ZIO[RunEnv, Throwable, Unit] => ZIO[RunEnv, Throwable, Unit] =
+    job =>
+      for {
         spark <- ZIO.access[SparkEnv](_.get.sparkEnv)
-        result <- process(jobTime)
+        result <- job
           .ensuring(
             ZIO
               .effect(spark.stop())
@@ -104,4 +123,14 @@ object Job {
           )
         _ <- zio.console.putStrLn(s"Executed grafink job with spark ${spark.version}: $result")
       } yield ()
+
+  /**
+   * Runs the spark job to load data into JanusGraph
+   */
+  val runGrafinkJob: JobTime => ZIO[RunEnv, Throwable, Unit] = jobTime => runJob(process(jobTime))
+
+  /**
+   * Runs the spark job to delete data present in IDManager storage
+   */
+  val runGrafinkDeleteJob: JobTime => ZIO[RunEnv, Throwable, Unit] = jobTime => runJob(delete(jobTime))
 }

--- a/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
@@ -26,16 +26,14 @@ import org.apache.hadoop.fs.{ FileSystem, Path }
 import zio.{ RIO, ZIO }
 import zio.logging.{ log, Logging }
 
+import com.astrolabsoftware.grafink.common.PartitionManager.{ paddedInt, toPathString }
+
 case class PartitionPath(year: String, month: String, day: String)
 
-/**
- * Manages the partition path for the data
- * @param startDate
- * @param duration
- */
-case class PartitionManager(startDate: LocalDate, duration: Int) {
+trait PartitionManager {
 
-  import PartitionManager._
+  def startDate: LocalDate
+  def duration: Int
 
   /**
    * Given the date, convert into PartitionPath instance
@@ -44,9 +42,9 @@ case class PartitionManager(startDate: LocalDate, duration: Int) {
    */
   implicit def toPartitionPath(date: LocalDate): PartitionPath =
     PartitionPath(
-      year = s"${f"${date.getYear}%02d"}",
-      month = paddedInt(date.getMonth.getValue),
-      day = paddedInt(date.getDayOfMonth)
+      year = s"${date.getYear}",
+      month = s"${date.getMonth.getValue}",
+      day = s"${date.getDayOfMonth}"
     )
 
   /**
@@ -112,7 +110,31 @@ case class PartitionManager(startDate: LocalDate, duration: Int) {
           )
       })
       .ignore
+}
 
+case class PartitionManagerImpl(override val startDate: LocalDate, override val duration: Int) extends PartitionManager
+
+/**
+ * Manages the partition path for the data, after padding the partition values
+ * @param startDate
+ * @param duration
+ */
+case class PaddedPartitionManager(override val startDate: LocalDate, override val duration: Int)
+    extends PartitionManager {
+
+  import PartitionManager._
+
+  /**
+   * Given the date, convert into PartitionPath instance with padded values
+   * @param date
+   * @return
+   */
+  implicit override def toPartitionPath(date: LocalDate): PartitionPath =
+    PartitionPath(
+      year = s"${f"${date.getYear}%02d"}",
+      month = paddedInt(date.getMonth.getValue),
+      day = paddedInt(date.getDayOfMonth)
+    )
 }
 
 /**
@@ -124,7 +146,7 @@ object PartitionManager {
   val dateFormat: DateTimeFormatter  = DateTimeFormatter.ofPattern("yyyy-MM-dd")
   val partitionColumns: List[String] = List("year", "month", "day")
 
-  def apply(duration: Int): PartitionManager = PartitionManager(LocalDate.now, duration)
+  def apply(duration: Int): PaddedPartitionManager = PaddedPartitionManager(LocalDate.now, duration)
 
   /**
    * Given the base path and partitionPath object, generates full partition path string

--- a/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
@@ -100,15 +100,16 @@ trait PartitionManager {
   def deletePartitions(basePath: String, fs: FileSystem): ZIO[Logging, Throwable, Unit] =
     for {
       paths <- getValidPartitionPathStrings(basePath, fs)
-    } yield ZIO
-      .collectAll_(paths.map { path =>
-        RIO
-          .effect(fs.delete(new Path(path), true))
-          .tapBoth(
-            fail => log.error(s"error deleting path $path, failure: $fail"),
-            _ => log.info(s"deleted partition path $path")
-          )
-      })
+      _ <- ZIO
+        .collectAll(paths.map { path =>
+          RIO
+            .effect(fs.delete(new Path(path), true))
+            .tapBoth(
+              fail => log.error(s"error deleting path $path, failure: $fail"),
+              _ => log.info(s"deleted partition path $path")
+            )
+        })
+    } yield ()
 }
 
 case class PartitionManagerImpl(override val startDate: LocalDate, override val duration: Int) extends PartitionManager

--- a/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
@@ -101,15 +101,14 @@ trait PartitionManager {
     for {
       paths <- getValidPartitionPathStrings(basePath, fs)
     } yield ZIO
-      .collectAll(paths.map { path =>
+      .collectAll_(paths.map { path =>
         RIO
           .effect(fs.delete(new Path(path), true))
-          .fold(
+          .tapBoth(
             fail => log.error(s"error deleting path $path, failure: $fail"),
             _ => log.info(s"deleted partition path $path")
           )
       })
-      .ignore
 }
 
 case class PartitionManagerImpl(override val startDate: LocalDate, override val duration: Int) extends PartitionManager

--- a/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
@@ -52,11 +52,11 @@ case class JanusGraphConfig(
   storage: JanusGraphStorageConfig
 )
 
-case class SparkPathConfig(dataPath: String)
+case class IDManagerSparkConfig(dataPath: String, clearOnDelete: Boolean)
 
 case class HBaseColumnConfig(tableName: String, cf: String, qualifier: String)
 
-case class IDManagerConfig(spark: SparkPathConfig, hbase: HBaseColumnConfig)
+case class IDManagerConfig(spark: IDManagerSparkConfig, hbase: HBaseColumnConfig)
 
 final case class GrafinkConfiguration(
   reader: ReaderConfig,

--- a/src/main/scala/com/astrolabsoftware/grafink/processor/VertexProcessor.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/processor/VertexProcessor.scala
@@ -18,14 +18,16 @@ package com.astrolabsoftware.grafink.processor
 
 import org.apache.spark.sql.{ DataFrame, Row }
 import org.apache.spark.sql.types.DataType
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.{ GraphTraversal, GraphTraversalSource }
 import org.apache.tinkerpop.gremlin.structure.T
 import org.janusgraph.core.JanusGraph
 import org.janusgraph.graphdb.database.StandardJanusGraph
-import zio.{ Has, URLayer, ZIO, ZLayer }
-import zio.logging.Logging
+import zio.{ Has, URLayer, ZIO, ZLayer, ZManaged }
+import zio.logging.{ log, Logging }
 
 import com.astrolabsoftware.grafink.JanusGraphEnv.withGraph
 import com.astrolabsoftware.grafink.common.Utils
+import com.astrolabsoftware.grafink.logging.Logger
 import com.astrolabsoftware.grafink.models.JanusGraphConfig
 import com.astrolabsoftware.grafink.models.config.Config
 
@@ -37,6 +39,7 @@ object VertexProcessor {
 
   trait Service {
     def process(df: DataFrame): ZIO[Logging, Throwable, Unit]
+    def delete(df: DataFrame): ZIO[Logging, Throwable, Unit]
   }
 
   val live: URLayer[Has[JanusGraphConfig] with Logging, VertexProcessorService] =
@@ -49,6 +52,8 @@ object VertexProcessor {
   def process(df: DataFrame): ZIO[VertexProcessorService with Logging, Throwable, Unit] =
     ZIO.accessM(_.get.process(df))
 
+  def delete(df: DataFrame): ZIO[VertexProcessorService with Logging, Throwable, Unit] =
+    ZIO.accessM(_.get.delete(df))
 }
 
 final case class VertexProcessorLive(config: JanusGraphConfig) extends VertexProcessor.Service {
@@ -103,6 +108,49 @@ final case class VertexProcessorLive(config: JanusGraphConfig) extends VertexPro
     } yield ()
   }
 
+  def deleteJob(
+    config: JanusGraphConfig,
+    graph: JanusGraph,
+    partition: Iterator[Row]
+  ): ZIO[Logging, Throwable, Unit] = {
+
+    val batchSize = config.vertexLoader.batchSize
+    val g: ZManaged[Any, Nothing, GraphTraversalSource] =
+      ZManaged.make(ZIO.succeed(graph.traversal()))(g =>
+        ZIO
+          .effect(g.close())
+          .fold(
+            f => log.info(s"Exception closing graph traversal $f"),
+            _ => log.info("Graph traversal closed successfully")
+          )
+      )
+    val idManager = graph.asInstanceOf[StandardJanusGraph].getIDManager
+    val kgroup    = partition.grouped(batchSize)
+    val l = (g: GraphTraversalSource) =>
+      kgroup.map(group =>
+        for {
+          _ <- ZIO.collectAll_(
+            group.map { r =>
+              val id = idManager.toVertexId(r.getAs[Long]("id"))
+              for {
+                vertex <- ZIO.effect(g.V(java.lang.Long.valueOf(id)).next())
+                _      <- ZIO.effect(vertex.remove())
+                // Strangely need to commit on every removal, otherwise we end up with some vertex not being deleted
+                _ <- ZIO.effect(graph.tx.commit) catchAll (e => log.error(s"Error deleting vertex with id $id : $e"))
+              } yield ()
+            }
+          )
+        } yield ()
+      )
+
+    val effect = (g: GraphTraversalSource) =>
+      for {
+        _ <- ZIO.collectAll_(l(g).toIterable)
+        _ <- ZIO.effect(graph.tx.commit)
+      } yield ()
+    g.use(g => effect(g))
+  }
+
   def getDataTypeForVertexProperties(vertexProperties: List[String], df: DataFrame): Map[String, DataType] = {
     val vertexPropertiesSet = vertexProperties.toSet
     df.schema.fields.filter(f => vertexPropertiesSet.contains(f.name)).map(f => f.name -> f.dataType).toMap
@@ -123,5 +171,16 @@ final case class VertexProcessorLive(config: JanusGraphConfig) extends VertexPro
     val load = loadFunc
 
     ZIO.effect(df.foreachPartition(load))
+  }
+
+  override def delete(df: DataFrame): ZIO[Logging, Throwable, Unit] = {
+    val jobFunc = deleteJob _
+    def deleteFunc: (Iterator[Row]) => Unit = (partition: Iterator[Row]) => {
+      val c           = config
+      val executorJob = withGraph(c, graph => jobFunc(c, graph, partition))
+      zio.Runtime.default.unsafeRun(executorJob.provideLayer(Logger.live))
+    }
+    val delete = deleteFunc
+    ZIO.effect(df.foreachPartition(delete))
   }
 }

--- a/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
@@ -88,7 +88,9 @@ final class IDManagerSparkServiceLive(spark: SparkSession, config: IDManagerConf
   override def readAll(schema: StructType, tableName: String): ZIO[Logging, Throwable, DataFrame] =
     ZIO.effect(spark.read.parquet(s"${config.spark.dataPath}/$tableName")).catchSome {
       // Catch case where there is no data to read, this means this is being run on a new setup
-      case e: org.apache.spark.sql.AnalysisException if e.message.contains("Unable to infer schema for Parquet") =>
+      case e: org.apache.spark.sql.AnalysisException
+          if e.message.contains("Unable to infer schema for Parquet") ||
+            e.message.contains("Path does not exist") =>
         for {
           _ <- log.warn(s"No data found at ${config.spark.dataPath}/$tableName, returning empty dataframe")
         } yield spark.createDataFrame(

--- a/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.types.{ LongType, StructField, StructType }
 import zio._
 import zio.logging.{ log, Logging }
 
-import com.astrolabsoftware.grafink.Job.{ JobTime, SparkEnv, VertexData }
+import com.astrolabsoftware.grafink.Job.{ SparkEnv, VertexData }
 import com.astrolabsoftware.grafink.common.PartitionManager
 import com.astrolabsoftware.grafink.models.GrafinkException.GetIdException
 import com.astrolabsoftware.grafink.models.IDManagerConfig

--- a/src/main/scala/com/astrolabsoftware/grafink/services/reader/Reader.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/services/reader/Reader.scala
@@ -16,14 +16,13 @@
  */
 package com.astrolabsoftware.grafink.services.reader
 
-import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import zio.{ Has, RIO, URLayer, ZIO, ZLayer }
 import zio.logging.{ log, Logging }
 
 import com.astrolabsoftware.grafink.Job.SparkEnv
-import com.astrolabsoftware.grafink.common.PartitionManager
+import com.astrolabsoftware.grafink.common.{ PartitionManager, Utils }
 import com.astrolabsoftware.grafink.models.GrafinkException.NoDataException
 import com.astrolabsoftware.grafink.models.ReaderConfig
 import com.astrolabsoftware.grafink.models.config.Config
@@ -37,7 +36,9 @@ object Reader {
 
   trait Service {
     def config: ReaderConfig
-    def read(partitionManager: PartitionManager): RIO[Logging, DataFrame]
+    def read(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame]
+    def readAndProcess(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame]
+    def readAndProcess(partitionManager: PartitionManager): RIO[Logging, DataFrame]
   }
 
   val live: URLayer[SparkEnv with Logging with Has[ReaderConfig], ReaderService] =
@@ -48,21 +49,16 @@ object Reader {
       } yield new Service {
         override def config: ReaderConfig = readerConf
 
-        override def read(partitionManager: PartitionManager): RIO[Logging, DataFrame] =
-          ZIO
-            .effect(FileSystem.get(spark.sparkContext.hadoopConfiguration))
-            .bracket(fs =>
-              ZIO
-                .effect(fs.close())
-                .fold(failure => log.error(s"Error closing filesystem: $failure"), _ => log.info(s""))
-            )(fs =>
+        override def read(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame] =
+          Utils.withFileSystem {
+            fs =>
               for {
-                readPaths <- partitionManager.getValidPartitionPathStrings(readerConf.basePath, fs)
+                readPaths <- partitionManager.getValidPartitionPathStrings(basePath, fs)
                 _         <- log.info(s"Reading data from paths: ${readPaths.mkString}")
                 df <- if (readPaths.isEmpty) {
                   ZIO.fail(
                     NoDataException(
-                      s"No data at basepath ${readerConf.basePath} for startdate = ${partitionManager.startDate} and duration = ${partitionManager.duration}"
+                      s"No data at basepath ${readerConf.basePath} for startdate = ${partitionManager.startDate}, duration = ${partitionManager.duration}"
                     )
                   )
                 } else {
@@ -73,15 +69,28 @@ object Reader {
                       .load(readPaths: _*)
                   )
                 }
-                colsToSelect = config.keepCols.map(col(_)) ++ List(col("year"), col("month"), col("day"))
-                colsRenamed  = config.keepColsRenamed.map(c => col(c.f).as(c.t))
-                dfPruned     = df.select(colsToSelect ++ colsRenamed: _*)
-              } yield dfPruned
-            )
+              } yield df
+          }(spark)
+
+        override def readAndProcess(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame] =
+          for {
+            df <- read(basePath, partitionManager)
+            colsToSelect = config.keepCols.map(col(_)) ++ PartitionManager.partitionColumns.map(col)
+            colsRenamed  = config.keepColsRenamed.map(c => col(c.f).as(c.t))
+            dfPruned     = df.select(colsToSelect ++ colsRenamed: _*)
+          } yield dfPruned
+
+        override def readAndProcess(partitionManager: PartitionManager): RIO[Logging, DataFrame] =
+          readAndProcess(readerConf.basePath, partitionManager)
       }
     )
 
-  def read(partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
-    RIO.accessM(_.get.read(partitionManager))
+  def readAndProcess(partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
+    RIO.accessM(_.get.readAndProcess(partitionManager))
 
+  def readAndProcess(basePath: String, partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
+    RIO.accessM(_.get.readAndProcess(basePath, partitionManager))
+
+  def read(basePath: String, partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
+    RIO.accessM(_.get.read(basePath, partitionManager))
 }

--- a/src/templates/bash-template
+++ b/src/templates/bash-template
@@ -37,6 +37,8 @@ do
     --duration)
       shift
       VARS="$VARS--duration $1 ";;
+    --delete)
+      VARS="$VARS--delete ";;
     --driver-memory)
       shift
       SPARKVARS="$SPARKVARS--driver-memory $1 ";;

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -11,6 +11,7 @@ reader {
 idManager {
   spark {
     dataPath = "/test/intermediate/base/path"
+    clearOnDelete = false
   }
   hbase {
     tableName = "IDManagement"

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -20,7 +20,7 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
       test("PartitionManager will correctly generate read paths") {
         val dateString       = "2019-02-01"
         val date             = LocalDate.parse(dateString, dateFormat)
-        val partitionManager = PartitionManager(startDate = date, duration = 2)
+        val partitionManager = PaddedPartitionManager(startDate = date, duration = 2)
 
         assert(partitionManager.partitionPaths)(
           hasSameElements(List(PartitionPath("2019", "02", "01"), PartitionPath("2019", "02", "02")))
@@ -31,7 +31,7 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
         val path             = getClass.getResource(dataPath).getPath
         val dateString       = "2019-02-01"
         val date             = LocalDate.parse(dateString, dateFormat)
-        val partitionManager = PartitionManager(startDate = date, duration = 7)
+        val partitionManager = PaddedPartitionManager(startDate = date, duration = 7)
 
         val sparkLayer = SparkTestEnv.test
 

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -17,7 +17,16 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
 
   def spec: ZSpec[Environment, Failure] =
     suite("PartitionManagerSpec")(
-      test("PartitionManager will correctly generate read paths") {
+      test("PartitionManagerImpl will correctly generate read paths") {
+        val dateString       = "2019-02-01"
+        val date             = LocalDate.parse(dateString, dateFormat)
+        val partitionManager = PartitionManagerImpl(startDate = date, duration = 2)
+
+        assert(partitionManager.partitionPaths)(
+          hasSameElements(List(PartitionPath("2019", "2", "1"), PartitionPath("2019", "2", "2")))
+        )
+      },
+      test("PaddedPartitionManager will correctly generate read paths") {
         val dateString       = "2019-02-01"
         val date             = LocalDate.parse(dateString, dateFormat)
         val partitionManager = PaddedPartitionManager(startDate = date, duration = 2)
@@ -26,7 +35,7 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
           hasSameElements(List(PartitionPath("2019", "02", "01"), PartitionPath("2019", "02", "02")))
         )
       },
-      testM("PartitionManager will correctly filter out non-existing paths") {
+      testM("PaddedPartitionManager will correctly filter out non-existing paths") {
         val dataPath         = "/data"
         val path             = getClass.getResource(dataPath).getPath
         val dateString       = "2019-02-01"

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -3,15 +3,20 @@ package com.astrolabsoftware.grafink.common
 import java.time.LocalDate
 
 import org.apache.hadoop.fs.FileSystem
-import zio.{ console, ZIO }
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{ IntegerType, StringType, StructField, StructType }
+import zio.{ console, ZIO, ZLayer }
 import zio.blocking.Blocking
 import zio.test._
 import zio.test.Assertion._
-import zio.test.environment.{ TestClock, TestConsole }
+import zio.test.environment.TestConsole
 
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
-import com.astrolabsoftware.grafink.utils.SparkTestEnv
+import com.astrolabsoftware.grafink.models._
+import com.astrolabsoftware.grafink.services.IDManagerSparkService.IDManagerSparkService
+import com.astrolabsoftware.grafink.services.IDManagerSparkService
+import com.astrolabsoftware.grafink.utils.{ SparkTestEnv, TempDirService }
 
 object PartitionManagerSpec extends DefaultRunnableSpec {
 
@@ -62,6 +67,76 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
         assertM(app.provideLayer((Blocking.live >>> sparkLayer) ++ Logger.test))(
           hasSameElements(List(s"$path/year=2019/month=02/day=01"))
         )
+      },
+      testM("PartitionManager will correctly delete partitions") {
+        case class SampleData(payLoad: String, year: Int, month: Int, day: Int)
+
+        val dateString          = "2019-02-01"
+        val date                = LocalDate.parse(dateString, dateFormat)
+        val tempDirServiceLayer = ((zio.console.Console.live) >>> TempDirService.test)
+        val runtime             = zio.Runtime.default
+        val tempDir =
+          runtime.unsafeRun(TempDirService.createTempDir.provideLayer(tempDirServiceLayer ++ zio.console.Console.live))
+
+        val janusConfig =
+          JanusGraphConfig(
+            SchemaConfig(
+              vertexPropertyCols = List("rfscore", "snnscore", "objectId"),
+              vertexLabel = "type",
+              edgeLabels = List()
+            ),
+            VertexLoaderConfig(10),
+            EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
+            JanusGraphStorageConfig("", 0, tableName = "test")
+          )
+
+        val idManagerConfig =
+          IDManagerConfig(IDManagerSparkConfig(tempDir.getAbsolutePath, false), HBaseColumnConfig("", "", ""))
+
+        val idManagerConfigLayer = ZLayer.succeed(idManagerConfig)
+
+        // We are working with 4 days from date
+        val partitionManager = PartitionManagerImpl(date, 4)
+
+        val sampleSchema = StructType(
+          fields = Array(
+            StructField("payLoad", StringType),
+            StructField("year", IntegerType),
+            StructField("month", IntegerType),
+            StructField("day", IntegerType)
+          )
+        )
+        val app =
+          for {
+            spark <- SparkTestEnv.sparkEnv
+            df = spark.createDataFrame(
+              spark.sparkContext.parallelize(
+                List(
+                  Row("Some", 2019, 2, 1),
+                  Row("Some", 2019, 2, 3),
+                  Row("Some", 2019, 2, 5)
+                )
+              ),
+              sampleSchema
+            )
+            idManager <- ZIO.access[IDManagerSparkService](_.get)
+            // This will create the partitions and write the data
+            vertexData <- idManager.process(df, janusConfig.storage.tableName)
+            basePath = s"${idManagerConfig.spark.dataPath}/${janusConfig.storage.tableName}"
+            _             <- Utils.withFileSystem(fs => partitionManager.deletePartitions(basePath, fs))(df.sparkSession)
+            afterDeletion <- ZIO.effect(spark.read.parquet(basePath).drop("id").collect)
+            _             <- TempDirService.removeTempDir(tempDir)
+          } yield afterDeletion.toList
+
+        val logger     = Logger.test
+        val sparkLayer = SparkTestEnv.test
+        val idManagerLayer =
+          (logger ++ sparkLayer ++ ((tempDirServiceLayer ++ TestConsole.debug) >>> idManagerConfigLayer)) >>> IDManagerSparkService.live
+
+        val layer =
+          tempDirServiceLayer ++ TestConsole.debug ++ idManagerLayer ++ logger ++ sparkLayer
+        // Only data for 5th day is retained
+        assertM(app.provideLayer(layer))(hasSameElementsDistinct(List(Row("Some", 2019, 2, 5))))
       }
     )
 }

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
@@ -4,13 +4,18 @@ import java.time.LocalDate
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.{ DoubleType, LongType, StringType, StructField, StructType }
+import org.apache.tinkerpop.gremlin.structure.T
+import org.janusgraph.graphdb.database.StandardJanusGraph
 import zio.{ ZIO, ZLayer }
 import zio.test.{ DefaultRunnableSpec, _ }
 import zio.test.Assertion._
 import zio.test.environment.TestConsole
 
 import com.astrolabsoftware.grafink.Job.JobTime
-import com.astrolabsoftware.grafink.common.PaddedPartitionManager
+import com.astrolabsoftware.grafink.common.{ PaddedPartitionManager, Utils }
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
 import com.astrolabsoftware.grafink.models._
@@ -45,8 +50,6 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
           JanusGraphStorageConfig("", 0, tableName = "test")
         )
-
-      val jobTime = JobTime(date, 1)
 
       val tempDirServiceLayer = ((zio.console.Console.live) >>> TempDirService.test)
       val runtime             = zio.Runtime.default
@@ -86,6 +89,75 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
       assertM(app.provideLayer(layer))(
         hasSameElementsDistinct(List("ZTF19acmcetc", "ZTF17aaanypg", "ZTF19acmbxka", "ZTF19acmbxfe", "ZTF19acmbtac"))
       )
+    },
+    testM("VertexProcessor will correctly delete already added input alerts into janusgraph") {
+      val dateString = "2019-02-01"
+      val date       = LocalDate.parse(dateString, dateFormat)
+      val dataPath   = "/data"
+      val path       = getClass.getResource(dataPath).getPath
+      val logger     = Logger.test
+
+      val janusConfig =
+        JanusGraphConfig(
+          SchemaConfig(
+            vertexPropertyCols = List("rfscore", "objectId"),
+            vertexLabel = "type",
+            edgeLabels = List()
+          ),
+          VertexLoaderConfig(1),
+          EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
+          JanusGraphStorageConfig("", 0, tableName = "test")
+        )
+
+      val vertexSchema = StructType(
+        fields = Array(
+          StructField("id", LongType, false),
+          StructField("objectId", StringType, false),
+          StructField("rfscore", DoubleType, false)
+        )
+      )
+
+      val schemaMap = vertexSchema.map(f => f.name -> f.dataType).toMap
+
+      val verticesList = List(
+        new GenericRowWithSchema(Array(1L, "objectid1", 0.345), vertexSchema),
+        new GenericRowWithSchema(Array(2L, "objectid2", 0.9987), vertexSchema),
+        new GenericRowWithSchema(Array(3L, "objectid3", 0.0), vertexSchema)
+      )
+      // Delete only first 2 vertices
+      val verticesToDelete = verticesList.dropRight(1).toIterator
+
+      @inline
+      def getVertexProperties(r: Row): Seq[AnyRef] =
+        List("objectId", "rfscore").flatMap { property =>
+          val dType = Utils.getClassTag(schemaMap(property))
+          List(property, r.getAs[dType.type](property))
+        }
+
+      def getVertexParams(r: Row, id: java.lang.Long): Seq[AnyRef] = Seq(T.id, id) ++ getVertexProperties(r)
+
+      val app = for {
+        output <- JanusGraphTestEnv
+          .test(janusConfig)
+          .use {
+            graph =>
+              val idMgr = graph.asInstanceOf[StandardJanusGraph].getIDManager
+              val vertexParams = verticesList.map(vertex =>
+                getVertexParams(vertex, java.lang.Long.valueOf(idMgr.toVertexId(vertex.getAs[Long]("id"))))
+              )
+              for {
+                _ <- ZIO.effect(vertexParams.foreach(v => graph.addVertex(v: _*)))
+                _ <- ZIO.effect(graph.tx.commit())
+                vertexProcessorLive = VertexProcessorLive(janusConfig)
+                _ <- vertexProcessorLive.deleteJob(graph, verticesToDelete)
+              } yield graph.traversal().V().count().toList.asScala.toList.head
+          }
+      } yield output
+
+      val vertexProcessorLayer = (sparkLayer ++ ZLayer.succeed(janusConfig) ++ logger) >>> VertexProcessor.live
+      val layer                = TestConsole.debug ++ vertexProcessorLayer ++ logger ++ sparkLayer
+
+      assertM(app.provideLayer(layer))(equalTo(java.lang.Long.valueOf(1L)))
     }
   )
 }

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
@@ -75,6 +75,7 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
               _ <- vertexProcessorLive
                 .job(janusConfig, graph, dataTypeForVertexPropertyCols, vertexData.current.collect.toIterator)
               g = graph.traversal()
+              _ <- TempDirService.removeTempDir(tempDir)
             } yield g.V().toList.asScala.map(_.property("objectId").value().toString).toList
           )
       } yield output

--- a/src/test/scala/com/astrolabsoftware/grafink/reader/ReaderSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/reader/ReaderSpec.scala
@@ -6,7 +6,7 @@ import zio._
 import zio.test._
 import zio.test.Assertion._
 
-import com.astrolabsoftware.grafink.common.PartitionManager
+import com.astrolabsoftware.grafink.common.PaddedPartitionManager
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
 import com.astrolabsoftware.grafink.models.{ Parquet, ReaderConfig }
@@ -28,7 +28,7 @@ object ReaderSpec extends DefaultRunnableSpec {
 
       val app =
         for {
-          df <- Reader.read(PartitionManager(date, 1))
+          df <- Reader.readAndProcess(PaddedPartitionManager(date, 1))
         } yield df.count
 
       val layer = ((logger ++ config ++ sparkLayer) >>> Reader.live) ++ logger

--- a/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
@@ -13,18 +13,7 @@ import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.hbase.HBaseClientService.HBaseClientService
 import com.astrolabsoftware.grafink.hbase.HBaseClientServiceMock
 import com.astrolabsoftware.grafink.logging.Logger
-import com.astrolabsoftware.grafink.models.{
-  EdgeLoaderConfig,
-  EdgeRulesConfig,
-  HBaseColumnConfig,
-  IDManagerConfig,
-  JanusGraphConfig,
-  JanusGraphStorageConfig,
-  SchemaConfig,
-  SimilarityConfig,
-  SparkPathConfig,
-  VertexLoaderConfig
-}
+import com.astrolabsoftware.grafink.models._
 
 object IDManagerSpec extends DefaultRunnableSpec {
 
@@ -36,7 +25,8 @@ object IDManagerSpec extends DefaultRunnableSpec {
       val id                  = 1234L
       val jobTime             = JobTime(LocalDate.parse(date, dateFormat), 1)
       val app                 = IDManager.fetchID(jobTime)
-      val idConfigLayer       = ZLayer.succeed(IDManagerConfig(SparkPathConfig(""), HBaseColumnConfig("", "", "")))
+      val idConfigLayer =
+        ZLayer.succeed(IDManagerConfig(IDManagerSparkConfig("", false), HBaseColumnConfig("", "", "")))
       val janusConfigLayer =
         ZLayer.succeed(
           JanusGraphConfig(


### PR DESCRIPTION
This PR addresses #11  by adding a CL parameter ```--delete``` that runs Grafink in delete mode and deletes the data for the  startDate and duration. Also there is a configurable option to remove IDManager data on successful data deletion from the graph.