### PR TITLE
Add support for deleting data, add support for Indexing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ idManager {
   spark {
     // The base path where data will be generated. Note that partitioning of the original data is maintained
     dataPath = "/test/intermediate/base/path"
+    // Whether to clear IDManager data when running grafink in delete mode to delete data from JanusGraph
+    clearOnDelete = false
   }
   // This configuration is used by IDManager backed by HBase
   hbase {

--- a/README.md
+++ b/README.md
@@ -78,6 +78,38 @@ janusgraph {
         }
       }
     ]
+    // List of indices to add while loading the schema
+    index {
+      // Adds composite indices, handled by JanusGraph storage backend
+      composite = [
+        {
+          // Name of the index, should be unique
+          name = "objectIdIndex"
+          // Vertex property keys to index
+          properties = ["objectId"]
+        }
+      ]
+      // Adds mixed indices, handled by JanusGraph indexing backend
+      mixed = [
+        {
+          // Name of the index, should be unique
+          name = "rfScoreAndcdsx"
+          // Vertex property keys to index
+          properties = ["rfscore", "cdsxmatch"]
+        }
+      ]
+      // Adds vertex centric indices, handled by JanusGraph storage backend 
+      edge = [
+        {
+          // Name of the index, should be unique
+          name = "similarityIndex"
+          // Edge property keys to index, handled as 'RelationType' 
+          properties = ["value"]
+          // Edge Label for which to create the index
+          label = "similarity"
+        }
+      ]
+    }
   }
   // VertexLoader batch settings
   vertexLoader {
@@ -94,11 +126,20 @@ janusgraph {
       }
     }
   }
-  // Janusgraph storage settings
+  // JanusGraph storage settings
   storage {
     host: "127.0.0.1"
     port: 8182
     tableName = "TestJanusGraph"
+  }
+  // JanusGraph Indexing Backend settings
+  indexBackend {
+    // We use ElasticSearch here, but other backends like Solr can also be used
+    name = "elastic"
+    // Name of the Elasticsearch index to create for mixed indices
+    indexName = "elastictest"
+    // Host Port for Elasticsearch
+    host: "127.0.0.1:9200"
   }
 }
 
@@ -115,7 +156,13 @@ hbase {
 The schema model is described [here](docs/Schema-Model.md)
 Grafink tries to take advantage of bulk-loading feature in Janusgraph and disables
 the schema checks in place while loading vertices and edges.
-Hence it pre-creates the required graph schema (vertex properties, edge properties, labels etc).
+Hence it pre-creates the required graph schema.
+The supported Graph Elements while creating the schema include
+- Vertex Labels and Properties
+- Edge Label and Properties
+- Composite Index
+- Mixed Index
+- Vertex-Centric (Edge) Index
 
 There is a mechanism to check if the schema in the target storage table already exists
 and then load the schema only if needed.

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -85,7 +85,8 @@ object BuildHelper {
         "com.github.mrpowers" % "spark-daria" % sparkDariaVersion,
         "org.janusgraph" % "janusgraph-core" % janusGraphVersion,
         "org.janusgraph" % "janusgraph-hbase" % janusGraphVersion,
-        "org.janusgraph" % "janusgraph-inmemory" % janusGraphVersion
+        "org.janusgraph" % "janusgraph-inmemory" % janusGraphVersion,
+        "org.janusgraph" % "janusgraph-es" % janusGraphVersion
       )
 
   ) ++ basicSettings

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,7 +15,7 @@ reader {
 idManager {
   spark {
     dataPath = "/test/intermediate/base/path"
-    clearDataOnDelete = false
+    clearOnDelete = false
   }
   hbase {
     tableName = "IDManagement"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -73,6 +73,11 @@ janusgraph {
     port: 8182
     tableName = "TestJanusGraph"
   }
+  indexBackend {
+    name = "elastic"
+    indexName = "elastictest"
+    host: "127.0.0.1:9200"
+  }
 }
 
 hbase {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -37,6 +37,23 @@ janusgraph {
         }
       }
     ]
+    index {
+      composite = [
+        {
+          name = "objectIdIndex"
+          properties = ["objectId"]
+        }
+      ]
+      mixed = [
+      ]
+      edge = [
+        {
+          name = "similarityIndex"
+          properties = ["value"]
+          label = "similarity"
+        }
+      ]
+    }
   }
   vertexLoader {
     batchSize = 100

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,6 +15,7 @@ reader {
 idManager {
   spark {
     dataPath = "/test/intermediate/base/path"
+    clearDataOnDelete = false
   }
   hbase {
     tableName = "IDManagement"

--- a/src/main/scala/com/astrolabsoftware/grafink/Boot.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/Boot.scala
@@ -69,18 +69,18 @@ object Boot extends App {
         val vertexProcessorLayer = logger ++ configLayer >>> VertexProcessor.live
         val edgeProcessorLayer   = logger ++ configLayer >>> EdgeProcessor.live
 
-        Job
-          .runGrafinkJob(JobTime(argsConfig.startDate, argsConfig.duration))
-          .provideCustomLayer(
-            SparkEnv.cluster ++
-              configLayer ++
-              schemaLoaderLayer ++
-              readerLayer ++
-              idManagerLayer ++
-              vertexProcessorLayer ++
-              edgeProcessorLayer ++
-              logger
-          )
+        val jobTime = JobTime(argsConfig.startDate, argsConfig.duration)
+        val job     = if (argsConfig.deleteMode) Job.runGrafinkDeleteJob(jobTime) else Job.runGrafinkJob(jobTime)
+        job.provideCustomLayer(
+          SparkEnv.cluster ++
+            configLayer ++
+            schemaLoaderLayer ++
+            readerLayer ++
+            idManagerLayer ++
+            vertexProcessorLayer ++
+            edgeProcessorLayer ++
+            logger
+        )
       case None =>
         ZIO.fail(BadArgumentsException("Invalid command line arguments"))
     }

--- a/src/main/scala/com/astrolabsoftware/grafink/CLParser.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/CLParser.scala
@@ -24,7 +24,7 @@ import scopt.OptionParser
 
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 
-final case class ArgsConfig(confFile: String, startDate: LocalDate, duration: Int)
+final case class ArgsConfig(confFile: String, startDate: LocalDate, duration: Int, deleteMode: Boolean = false)
 
 /**
  * Command line parser for Grafink
@@ -69,6 +69,14 @@ trait CLParser {
         .text(
           "duration accepts duration (# of days) for which the job needs to process the data starting from startdate"
         )
+
+      opt[Unit]('d', "delete")
+        .optional()
+        .action((_, c) => c.copy(deleteMode = true))
+        .text(
+          "delete flag will delete the data for the specified startdate and duration for which the data has been computed by IDManager"
+        )
+
     }
 
   def validateDate(date: String): Boolean = Try { getLocalDate(date); true }.getOrElse(false)

--- a/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
@@ -92,6 +92,6 @@ object JanusGraphEnv extends Serializable {
         .set("graph.set-vertex-id", true)
         .open()
 
-  def withGraph(config: JanusGraphConfig, use: JanusGraph => ZIO[Any, Throwable, Unit]): ZIO[Any, Throwable, Unit] =
+  def withGraph[R](config: JanusGraphConfig, use: JanusGraph => ZIO[R, Throwable, Unit]): ZIO[R, Throwable, Unit] =
     ZIO.effect(withHBaseStorageWithBulkLoad(config)).bracket(releaseGraph, use)
 }

--- a/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
@@ -25,10 +25,12 @@ import com.astrolabsoftware.grafink.models.JanusGraphConfig
 
 object JanusGraphEnv extends Serializable {
 
-  def releaseGraph: JanusGraph => zio.URIO[Any, ZIO[Logging, Nothing, Unit]] =
+  def releaseGraph: JanusGraph => zio.URIO[Any, Unit] =
     (graph: JanusGraph) =>
-      ZIO
-        .effect(graph.close())
+      (for {
+        _ <- ZIO.effect(graph.tx().commit())
+        _ <- ZIO.effect(graph.close())
+      } yield ())
         .fold(_ => log.error(s"Error closing janusgraph instance"), _ => log.info(s"JanusGraph instance closed"))
 
   def hbaseBasic(config: JanusGraphConfig): ZManaged[Logging, Throwable, JanusGraph] =

--- a/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/JanusGraphEnv.scala
@@ -59,40 +59,59 @@ object JanusGraphEnv extends Serializable {
         .set("graph.set-vertex-id", true)
         .open()
 
-  def withHBaseStorage: JanusGraphConfig => JanusGraph =
-    config =>
-      JanusGraphFactory.build
-      // Use hbase as storage backend
-        .set("storage.backend", "hbase")
-        .set("graph.timestamps", TimestampProviders.MILLI)
-        // Configure hbase as storage backend
-        .set("storage.hostname", config.storage.host)
-        // Use the configured table name
-        .set("storage.hbase.table", config.storage.tableName)
-        // Manual transactions
-        .set("storage.transactions", false)
-        // Allow setting vertex ids
-        .set("graph.set-vertex-id", true)
-        .open()
+  def withHBaseStorage: JanusGraphConfig => JanusGraph = { config =>
+    val builder = JanusGraphFactory.build
+    // Use hbase as storage backend
+      .set("storage.backend", "hbase")
+      .set("graph.timestamps", TimestampProviders.MILLI)
+      // Configure hbase as storage backend
+      .set("storage.hostname", config.storage.host)
+      // Use the configured table name
+      .set("storage.hbase.table", config.storage.tableName)
+      // Manual transactions
+      .set("storage.transactions", false)
+      // Allow setting vertex ids
+      .set("graph.set-vertex-id", true)
+    if (config.schema.index.mixed.nonEmpty) {
+      withIndexingBackend(config, builder).open()
+    } else {
+      builder.open()
+    }
+  }
 
-  def withHBaseStorageWithBulkLoad: JanusGraphConfig => JanusGraph =
-    config =>
-      JanusGraphFactory.build
-      // Use hbase as storage backend
-        .set("storage.backend", "hbase")
-        .set("graph.timestamps", TimestampProviders.MILLI)
-        // Configure hbase as storage backend
-        .set("storage.hostname", config.storage.host)
-        // Use the configured table name
-        .set("storage.hbase.table", config.storage.tableName)
-        .set("schema.default", "none")
-        // Manual transactions
-        .set("storage.transactions", false)
-        // Use batch loading
-        .set("storage.batch-loading", true)
-        // Allow setting vertex ids
-        .set("graph.set-vertex-id", true)
-        .open()
+  def withHBaseStorageWithBulkLoad: JanusGraphConfig => JanusGraph = { config =>
+    val builder = JanusGraphFactory.build
+    // Use hbase as storage backend
+      .set("storage.backend", "hbase")
+      .set("graph.timestamps", TimestampProviders.MILLI)
+      // Configure hbase as storage backend
+      .set("storage.hostname", config.storage.host)
+      // Use the configured table name
+      .set("storage.hbase.table", config.storage.tableName)
+      .set("schema.default", "none")
+      // Manual transactions
+      .set("storage.transactions", false)
+      // Use batch loading
+      .set("storage.batch-loading", true)
+      // Allow setting vertex ids
+      .set("graph.set-vertex-id", true)
+    if (config.schema.index.mixed.nonEmpty) {
+      withIndexingBackend(config, builder).open()
+    } else {
+      builder.open()
+    }
+  }
+
+  def withIndexingBackend(config: JanusGraphConfig, builder: JanusGraphFactory.Builder): JanusGraphFactory.Builder = {
+    // Set Indexing backend option, since running with mixed indices
+    val backend     = config.indexBackend
+    val backendName = backend.name
+    builder
+      .set(s"index.$backendName.backend", "elasticsearch")
+      .set(s"index.$backendName.hostname", backend.host)
+      .set(s"index.$backendName.index-name", backend.indexName)
+      .set(s"index.$backendName.elasticsearch.bulk-refresh", "true")
+  }
 
   def withGraph[R](config: JanusGraphConfig, use: JanusGraph => ZIO[R, Throwable, Unit]): ZIO[R, Throwable, Unit] =
     ZIO.effect(withHBaseStorageWithBulkLoad(config)).bracket(releaseGraph, use)

--- a/src/main/scala/com/astrolabsoftware/grafink/Job.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/Job.scala
@@ -20,9 +20,9 @@ import java.time.LocalDate
 
 import org.apache.spark.sql.DataFrame
 import zio._
-import zio.logging.Logging
+import zio.logging.{ log, Logging }
 
-import com.astrolabsoftware.grafink.common.PartitionManager
+import com.astrolabsoftware.grafink.common.{ PaddedPartitionManager, PartitionManagerImpl, Utils }
 import com.astrolabsoftware.grafink.models.config._
 import com.astrolabsoftware.grafink.processor.{ EdgeProcessor, VertexProcessor }
 import com.astrolabsoftware.grafink.processor.EdgeProcessor.EdgeProcessorService
@@ -63,9 +63,9 @@ object Job {
     jobTime =>
       for {
         janusGraphConfig <- Config.janusGraphConfig
-        partitionManager = PartitionManager(jobTime.day, jobTime.duration)
+        partitionManager = PaddedPartitionManager(jobTime.day, jobTime.duration)
         // read current data
-        df <- Reader.read(partitionManager)
+        df <- Reader.readAndProcess(partitionManager)
         _ <- JanusGraphEnv
           .hbaseBasic(janusGraphConfig)
           .use(graph =>
@@ -86,14 +86,33 @@ object Job {
         )
       } yield ()
 
-  /**
-   * Runs the spark job to load data into JanusGraph
-   */
-  val runGrafinkJob: JobTime => ZIO[RunEnv, Throwable, Unit] =
+  val delete: JobTime => ZIO[RunEnv, Throwable, Unit] =
     jobTime =>
       for {
+        janusGraphConfig <- Config.janusGraphConfig
+        idManagerConfig  <- Config.idManagerConfig
+        basePath         = s"${idManagerConfig.spark.dataPath}/${janusGraphConfig.storage.tableName}"
+        partitionManager = PartitionManagerImpl(jobTime.day, jobTime.duration)
+        // read data for the specified date from idmanager data path
+        df <- Reader.read(basePath, partitionManager)
+        // Delete vertices
+        _ <- VertexProcessor.delete(df)
+        _ <- if (idManagerConfig.spark.clearOnDelete) {
+          // Clear IdManagerData as well
+          Utils.withFileSystem(fs => partitionManager.deletePartitions(basePath, fs))(df.sparkSession)
+        } else {
+          log.info(s"Skipping deleting IDManager data")
+        }
+      } yield ()
+
+  /**
+   * Runs the spark job with specified job
+   */
+  val runJob: ZIO[RunEnv, Throwable, Unit] => ZIO[RunEnv, Throwable, Unit] =
+    job =>
+      for {
         spark <- ZIO.access[SparkEnv](_.get.sparkEnv)
-        result <- process(jobTime)
+        result <- job
           .ensuring(
             ZIO
               .effect(spark.stop())
@@ -104,4 +123,14 @@ object Job {
           )
         _ <- zio.console.putStrLn(s"Executed grafink job with spark ${spark.version}: $result")
       } yield ()
+
+  /**
+   * Runs the spark job to load data into JanusGraph
+   */
+  val runGrafinkJob: JobTime => ZIO[RunEnv, Throwable, Unit] = jobTime => runJob(process(jobTime))
+
+  /**
+   * Runs the spark job to delete data present in IDManager storage
+   */
+  val runGrafinkDeleteJob: JobTime => ZIO[RunEnv, Throwable, Unit] = jobTime => runJob(delete(jobTime))
 }

--- a/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
@@ -26,16 +26,14 @@ import org.apache.hadoop.fs.{ FileSystem, Path }
 import zio.{ RIO, ZIO }
 import zio.logging.{ log, Logging }
 
+import com.astrolabsoftware.grafink.common.PartitionManager.{ paddedInt, toPathString }
+
 case class PartitionPath(year: String, month: String, day: String)
 
-/**
- * Manages the partition path for the data
- * @param startDate
- * @param duration
- */
-case class PartitionManager(startDate: LocalDate, duration: Int) {
+trait PartitionManager {
 
-  import PartitionManager._
+  def startDate: LocalDate
+  def duration: Int
 
   /**
    * Given the date, convert into PartitionPath instance
@@ -44,9 +42,9 @@ case class PartitionManager(startDate: LocalDate, duration: Int) {
    */
   implicit def toPartitionPath(date: LocalDate): PartitionPath =
     PartitionPath(
-      year = s"${f"${date.getYear}%02d"}",
-      month = paddedInt(date.getMonth.getValue),
-      day = paddedInt(date.getDayOfMonth)
+      year = s"${date.getYear}",
+      month = s"${date.getMonth.getValue}",
+      day = s"${date.getDayOfMonth}"
     )
 
   /**
@@ -112,7 +110,31 @@ case class PartitionManager(startDate: LocalDate, duration: Int) {
           )
       })
       .ignore
+}
 
+case class PartitionManagerImpl(override val startDate: LocalDate, override val duration: Int) extends PartitionManager
+
+/**
+ * Manages the partition path for the data, after padding the partition values
+ * @param startDate
+ * @param duration
+ */
+case class PaddedPartitionManager(override val startDate: LocalDate, override val duration: Int)
+    extends PartitionManager {
+
+  import PartitionManager._
+
+  /**
+   * Given the date, convert into PartitionPath instance with padded values
+   * @param date
+   * @return
+   */
+  implicit override def toPartitionPath(date: LocalDate): PartitionPath =
+    PartitionPath(
+      year = s"${f"${date.getYear}%02d"}",
+      month = paddedInt(date.getMonth.getValue),
+      day = paddedInt(date.getDayOfMonth)
+    )
 }
 
 /**
@@ -124,7 +146,7 @@ object PartitionManager {
   val dateFormat: DateTimeFormatter  = DateTimeFormatter.ofPattern("yyyy-MM-dd")
   val partitionColumns: List[String] = List("year", "month", "day")
 
-  def apply(duration: Int): PartitionManager = PartitionManager(LocalDate.now, duration)
+  def apply(duration: Int): PaddedPartitionManager = PaddedPartitionManager(LocalDate.now, duration)
 
   /**
    * Given the base path and partitionPath object, generates full partition path string

--- a/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
@@ -100,15 +100,16 @@ trait PartitionManager {
   def deletePartitions(basePath: String, fs: FileSystem): ZIO[Logging, Throwable, Unit] =
     for {
       paths <- getValidPartitionPathStrings(basePath, fs)
-    } yield ZIO
-      .collectAll_(paths.map { path =>
-        RIO
-          .effect(fs.delete(new Path(path), true))
-          .tapBoth(
-            fail => log.error(s"error deleting path $path, failure: $fail"),
-            _ => log.info(s"deleted partition path $path")
-          )
-      })
+      _ <- ZIO
+        .collectAll(paths.map { path =>
+          RIO
+            .effect(fs.delete(new Path(path), true))
+            .tapBoth(
+              fail => log.error(s"error deleting path $path, failure: $fail"),
+              _ => log.info(s"deleted partition path $path")
+            )
+        })
+    } yield ()
 }
 
 case class PartitionManagerImpl(override val startDate: LocalDate, override val duration: Int) extends PartitionManager

--- a/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/common/PartitionManager.scala
@@ -101,15 +101,14 @@ trait PartitionManager {
     for {
       paths <- getValidPartitionPathStrings(basePath, fs)
     } yield ZIO
-      .collectAll(paths.map { path =>
+      .collectAll_(paths.map { path =>
         RIO
           .effect(fs.delete(new Path(path), true))
-          .fold(
+          .tapBoth(
             fail => log.error(s"error deleting path $path, failure: $fail"),
             _ => log.info(s"deleted partition path $path")
           )
       })
-      .ignore
 }
 
 case class PartitionManagerImpl(override val startDate: LocalDate, override val duration: Int) extends PartitionManager

--- a/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
@@ -52,11 +52,11 @@ case class JanusGraphConfig(
   storage: JanusGraphStorageConfig
 )
 
-case class SparkPathConfig(dataPath: String)
+case class IDManagerSparkConfig(dataPath: String, clearOnDelete: Boolean)
 
 case class HBaseColumnConfig(tableName: String, cf: String, qualifier: String)
 
-case class IDManagerConfig(spark: SparkPathConfig, hbase: HBaseColumnConfig)
+case class IDManagerConfig(spark: IDManagerSparkConfig, hbase: HBaseColumnConfig)
 
 final case class GrafinkConfiguration(
   reader: ReaderConfig,

--- a/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
@@ -58,11 +58,14 @@ case class EdgeLoaderConfig(batchSize: Int, parallelism: Int, taskSize: Int, rul
 
 case class JanusGraphStorageConfig(host: String, port: Int, tableName: String)
 
+case class JanusGraphIndexBackendConfig(name: String, indexName: String, host: String)
+
 case class JanusGraphConfig(
   schema: SchemaConfig,
   vertexLoader: VertexLoaderConfig,
   edgeLoader: EdgeLoaderConfig,
-  storage: JanusGraphStorageConfig
+  storage: JanusGraphStorageConfig,
+  indexBackend: JanusGraphIndexBackendConfig
 )
 
 case class IDManagerSparkConfig(dataPath: String, clearOnDelete: Boolean)

--- a/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/models/Config.scala
@@ -33,7 +33,20 @@ case class HBaseConfig(zookeeper: HBaseZookeeperConfig)
 
 case class EdgeLabelConfig(name: String, properties: Map[String, String])
 
-case class SchemaConfig(vertexPropertyCols: List[String], vertexLabel: String, edgeLabels: List[EdgeLabelConfig])
+case class CompositeIndex(name: String, properties: List[String])
+
+case class MixedIndex(name: String, properties: List[String])
+
+case class EdgeIndex(name: String, properties: List[String], label: String)
+
+case class IndexConfig(composite: List[CompositeIndex], mixed: List[MixedIndex], edge: List[EdgeIndex])
+
+case class SchemaConfig(
+  vertexPropertyCols: List[String],
+  vertexLabel: String,
+  edgeLabels: List[EdgeLabelConfig],
+  index: IndexConfig
+)
 
 case class VertexLoaderConfig(batchSize: Int)
 

--- a/src/main/scala/com/astrolabsoftware/grafink/processor/VertexProcessor.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/processor/VertexProcessor.scala
@@ -18,14 +18,16 @@ package com.astrolabsoftware.grafink.processor
 
 import org.apache.spark.sql.{ DataFrame, Row }
 import org.apache.spark.sql.types.DataType
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.{ GraphTraversal, GraphTraversalSource }
 import org.apache.tinkerpop.gremlin.structure.T
 import org.janusgraph.core.JanusGraph
 import org.janusgraph.graphdb.database.StandardJanusGraph
-import zio.{ Has, URLayer, ZIO, ZLayer }
-import zio.logging.Logging
+import zio.{ Has, URLayer, ZIO, ZLayer, ZManaged }
+import zio.logging.{ log, Logging }
 
 import com.astrolabsoftware.grafink.JanusGraphEnv.withGraph
 import com.astrolabsoftware.grafink.common.Utils
+import com.astrolabsoftware.grafink.logging.Logger
 import com.astrolabsoftware.grafink.models.JanusGraphConfig
 import com.astrolabsoftware.grafink.models.config.Config
 
@@ -37,6 +39,7 @@ object VertexProcessor {
 
   trait Service {
     def process(df: DataFrame): ZIO[Logging, Throwable, Unit]
+    def delete(df: DataFrame): ZIO[Logging, Throwable, Unit]
   }
 
   val live: URLayer[Has[JanusGraphConfig] with Logging, VertexProcessorService] =
@@ -49,6 +52,8 @@ object VertexProcessor {
   def process(df: DataFrame): ZIO[VertexProcessorService with Logging, Throwable, Unit] =
     ZIO.accessM(_.get.process(df))
 
+  def delete(df: DataFrame): ZIO[VertexProcessorService with Logging, Throwable, Unit] =
+    ZIO.accessM(_.get.delete(df))
 }
 
 final case class VertexProcessorLive(config: JanusGraphConfig) extends VertexProcessor.Service {
@@ -103,6 +108,49 @@ final case class VertexProcessorLive(config: JanusGraphConfig) extends VertexPro
     } yield ()
   }
 
+  def deleteJob(
+    config: JanusGraphConfig,
+    graph: JanusGraph,
+    partition: Iterator[Row]
+  ): ZIO[Logging, Throwable, Unit] = {
+
+    val batchSize = config.vertexLoader.batchSize
+    val g: ZManaged[Any, Nothing, GraphTraversalSource] =
+      ZManaged.make(ZIO.succeed(graph.traversal()))(g =>
+        ZIO
+          .effect(g.close())
+          .fold(
+            f => log.info(s"Exception closing graph traversal $f"),
+            _ => log.info("Graph traversal closed successfully")
+          )
+      )
+    val idManager = graph.asInstanceOf[StandardJanusGraph].getIDManager
+    val kgroup    = partition.grouped(batchSize)
+    val l = (g: GraphTraversalSource) =>
+      kgroup.map(group =>
+        for {
+          _ <- ZIO.collectAll_(
+            group.map { r =>
+              val id = idManager.toVertexId(r.getAs[Long]("id"))
+              for {
+                vertex <- ZIO.effect(g.V(java.lang.Long.valueOf(id)).next())
+                _      <- ZIO.effect(vertex.remove())
+                // Strangely need to commit on every removal, otherwise we end up with some vertex not being deleted
+                _ <- ZIO.effect(graph.tx.commit) catchAll (e => log.error(s"Error deleting vertex with id $id : $e"))
+              } yield ()
+            }
+          )
+        } yield ()
+      )
+
+    val effect = (g: GraphTraversalSource) =>
+      for {
+        _ <- ZIO.collectAll_(l(g).toIterable)
+        _ <- ZIO.effect(graph.tx.commit)
+      } yield ()
+    g.use(g => effect(g))
+  }
+
   def getDataTypeForVertexProperties(vertexProperties: List[String], df: DataFrame): Map[String, DataType] = {
     val vertexPropertiesSet = vertexProperties.toSet
     df.schema.fields.filter(f => vertexPropertiesSet.contains(f.name)).map(f => f.name -> f.dataType).toMap
@@ -123,5 +171,16 @@ final case class VertexProcessorLive(config: JanusGraphConfig) extends VertexPro
     val load = loadFunc
 
     ZIO.effect(df.foreachPartition(load))
+  }
+
+  override def delete(df: DataFrame): ZIO[Logging, Throwable, Unit] = {
+    val jobFunc = deleteJob _
+    def deleteFunc: (Iterator[Row]) => Unit = (partition: Iterator[Row]) => {
+      val c           = config
+      val executorJob = withGraph(c, graph => jobFunc(c, graph, partition))
+      zio.Runtime.default.unsafeRun(executorJob.provideLayer(Logger.live))
+    }
+    val delete = deleteFunc
+    ZIO.effect(df.foreachPartition(delete))
   }
 }

--- a/src/main/scala/com/astrolabsoftware/grafink/schema/SchemaLoader.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/schema/SchemaLoader.scala
@@ -19,10 +19,14 @@ package com.astrolabsoftware.grafink.schema
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.types.{ DataType, StructType }
+import org.apache.tinkerpop.gremlin.structure.{ Direction, Vertex }
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
 import org.janusgraph.core.JanusGraph
 import org.janusgraph.core.Multiplicity._
-import zio.{ Has, URLayer, ZIO, ZLayer }
+import org.janusgraph.core.schema.{ Index, JanusGraphManagement, SchemaAction }
+import org.janusgraph.core.schema.JanusGraphManagement.IndexJobFuture
+import org.janusgraph.graphdb.database.management.ManagementSystem
+import zio.{ Has, Task, URLayer, ZIO, ZLayer }
 import zio.logging.{ log, Logging }
 
 import com.astrolabsoftware.grafink.common.Utils
@@ -43,6 +47,9 @@ object SchemaLoader {
     def loadSchema(graph: JanusGraph, dataSchema: StructType): ZIO[Logging, Throwable, Unit]
   }
 
+  private def enableIndices[T <: Index](indices: List[T], mgmt: JanusGraphManagement): List[Task[IndexJobFuture]] =
+    indices.map(i => ZIO.effect(mgmt.updateIndex(mgmt.getGraphIndex(i.name()), SchemaAction.ENABLE_INDEX)))
+
   val live: URLayer[Logging with Has[JanusGraphConfig], SchemaLoaderService] =
     ZLayer.fromEffect(
       for {
@@ -56,21 +63,27 @@ object SchemaLoader {
           val dataTypeForVertexPropertyCols: Map[String, DataType] =
             dataSchema.fields.map(f => f.name -> f.dataType).toMap
 
+          val compositeIndices = janusGraphConfig.schema.index.composite
+          val edgeIndices      = janusGraphConfig.schema.index.edge
+
           for {
-            vertextLabel <- ZIO.effect(graph.makeVertexLabel(janusGraphConfig.schema.vertexLabel).make)
+            // Need to rollback any active transaction since we add indices
+            _            <- ZIO.effect(graph.tx.rollback)
+            mgmt         <- ZIO.effect(graph.openManagement())
+            vertextLabel <- ZIO.effect(mgmt.makeVertexLabel(janusGraphConfig.schema.vertexLabel).make)
             // TODO: Detect the data type from input data types
             vertexProperties <- ZIO.effect(
               vertexPropertyCols.map { m =>
                 val dType = Utils.getClassTag(dataTypeForVertexPropertyCols(m))
-                graph.makePropertyKey(m).dataType(dType).make
+                mgmt.makePropertyKey(m).dataType(dType).make
               }
             )
-            _ <- ZIO.effect(graph.addProperties(vertextLabel, vertexProperties: _*))
+            _ <- ZIO.effect(mgmt.addProperties(vertextLabel, vertexProperties: _*))
             // TODO make this better
             _ <- ZIO.collectAll_(
               edgeLabels.map(l =>
                 for {
-                  label <- ZIO.effect(graph.makeEdgeLabel(l.name).multiplicity(MULTI).make)
+                  label <- ZIO.effect(mgmt.makeEdgeLabel(l.name).multiplicity(MULTI).make)
                   labelWithProperty <- if (!l.properties.isEmpty) {
                     // An edgelabel cardinality can only be SINGLE
                     val k = l.properties("key")
@@ -80,24 +93,57 @@ object SchemaLoader {
                       // https://github.com/JanusGraph/janusgraph/blob/master/janusgraph-core/src/main/java/org/janusgraph/graphdb/transaction/StandardJanusGraphTx.java#L924
                       // scalastyle:on
                       property <- ZIO.effect(
-                        graph
+                        mgmt
                           .makePropertyKey(k)
                           .dataType(Utils.getClassTagFromString(v))
                           .cardinality(Cardinality.single)
                           .make
                       )
-                      editedLabel <- ZIO.effect(graph.addProperties(label, property))
+                      editedLabel <- ZIO.effect(mgmt.addProperties(label, property))
                     } yield editedLabel
                   } else ZIO.succeed(label)
                 } yield labelWithProperty
               )
             )
+            // Add composite indices
+            compositeIndicesBuilt <- ZIO.collectAll(
+              compositeIndices.map { i =>
+                val keysToAdd = vertexProperties.filter(x => i.properties.contains(x.name()))
+                for {
+                  index          <- ZIO.effect(mgmt.buildIndex(i.name, classOf[Vertex]))
+                  indexToBuild   <- ZIO.effect(keysToAdd.foldLeft(index)((i, key) => i.addKey(key)))
+                  compositeIndex <- ZIO.effect(indexToBuild.buildCompositeIndex())
+                } yield compositeIndex
+              }
+            )
+
+            // Add edge indices
+            edgeIndicesBuilt <- ZIO.collectAll(
+              edgeIndices.map { i =>
+                for {
+                  keysToAdd <- ZIO.effect(i.properties.map(x => mgmt.getPropertyKey(x)))
+                  label     <- ZIO.effect(mgmt.getEdgeLabel(i.label))
+                  index     <- ZIO.effect(mgmt.buildEdgeIndex(label, i.name, Direction.BOTH, keysToAdd: _*))
+                } yield index
+              }
+            )
             _ <- ZIO
-              .effect(graph.tx.commit)
+              .effect(mgmt.commit)
               .tapBoth(
                 e => log.info(s"Something went wrong while creating schema $e"),
                 s => log.info(s"Successfully created Table schema")
               )
+
+            mgmt <- ZIO.effect(graph.openManagement())
+            // Enable indices
+            _ <- ZIO.collectAll_(
+              compositeIndicesBuilt.map(i =>
+                ZIO.effect(mgmt.updateIndex(mgmt.getGraphIndex(i.name()), SchemaAction.ENABLE_INDEX))
+              )
+            )
+
+            _ <- ZIO.effect(mgmt.commit)
+            _ <- ZIO.effect(graph.tx.commit)
           } yield ()
         }
 

--- a/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
@@ -88,7 +88,9 @@ final class IDManagerSparkServiceLive(spark: SparkSession, config: IDManagerConf
   override def readAll(schema: StructType, tableName: String): ZIO[Logging, Throwable, DataFrame] =
     ZIO.effect(spark.read.parquet(s"${config.spark.dataPath}/$tableName")).catchSome {
       // Catch case where there is no data to read, this means this is being run on a new setup
-      case e: org.apache.spark.sql.AnalysisException if e.message.contains("Unable to infer schema for Parquet") =>
+      case e: org.apache.spark.sql.AnalysisException
+          if e.message.contains("Unable to infer schema for Parquet") ||
+            e.message.contains("Path does not exist") =>
         for {
           _ <- log.warn(s"No data found at ${config.spark.dataPath}/$tableName, returning empty dataframe")
         } yield spark.createDataFrame(

--- a/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/services/IDManagerSparkService.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.types.{ LongType, StructField, StructType }
 import zio._
 import zio.logging.{ log, Logging }
 
-import com.astrolabsoftware.grafink.Job.{ JobTime, SparkEnv, VertexData }
+import com.astrolabsoftware.grafink.Job.{ SparkEnv, VertexData }
 import com.astrolabsoftware.grafink.common.PartitionManager
 import com.astrolabsoftware.grafink.models.GrafinkException.GetIdException
 import com.astrolabsoftware.grafink.models.IDManagerConfig

--- a/src/main/scala/com/astrolabsoftware/grafink/services/reader/Reader.scala
+++ b/src/main/scala/com/astrolabsoftware/grafink/services/reader/Reader.scala
@@ -16,14 +16,13 @@
  */
 package com.astrolabsoftware.grafink.services.reader
 
-import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import zio.{ Has, RIO, URLayer, ZIO, ZLayer }
 import zio.logging.{ log, Logging }
 
 import com.astrolabsoftware.grafink.Job.SparkEnv
-import com.astrolabsoftware.grafink.common.PartitionManager
+import com.astrolabsoftware.grafink.common.{ PartitionManager, Utils }
 import com.astrolabsoftware.grafink.models.GrafinkException.NoDataException
 import com.astrolabsoftware.grafink.models.ReaderConfig
 import com.astrolabsoftware.grafink.models.config.Config
@@ -37,7 +36,9 @@ object Reader {
 
   trait Service {
     def config: ReaderConfig
-    def read(partitionManager: PartitionManager): RIO[Logging, DataFrame]
+    def read(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame]
+    def readAndProcess(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame]
+    def readAndProcess(partitionManager: PartitionManager): RIO[Logging, DataFrame]
   }
 
   val live: URLayer[SparkEnv with Logging with Has[ReaderConfig], ReaderService] =
@@ -48,21 +49,16 @@ object Reader {
       } yield new Service {
         override def config: ReaderConfig = readerConf
 
-        override def read(partitionManager: PartitionManager): RIO[Logging, DataFrame] =
-          ZIO
-            .effect(FileSystem.get(spark.sparkContext.hadoopConfiguration))
-            .bracket(fs =>
-              ZIO
-                .effect(fs.close())
-                .fold(failure => log.error(s"Error closing filesystem: $failure"), _ => log.info(s""))
-            )(fs =>
+        override def read(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame] =
+          Utils.withFileSystem {
+            fs =>
               for {
-                readPaths <- partitionManager.getValidPartitionPathStrings(readerConf.basePath, fs)
+                readPaths <- partitionManager.getValidPartitionPathStrings(basePath, fs)
                 _         <- log.info(s"Reading data from paths: ${readPaths.mkString}")
                 df <- if (readPaths.isEmpty) {
                   ZIO.fail(
                     NoDataException(
-                      s"No data at basepath ${readerConf.basePath} for startdate = ${partitionManager.startDate} and duration = ${partitionManager.duration}"
+                      s"No data at basepath ${readerConf.basePath} for startdate = ${partitionManager.startDate}, duration = ${partitionManager.duration}"
                     )
                   )
                 } else {
@@ -73,15 +69,28 @@ object Reader {
                       .load(readPaths: _*)
                   )
                 }
-                colsToSelect = config.keepCols.map(col(_)) ++ List(col("year"), col("month"), col("day"))
-                colsRenamed  = config.keepColsRenamed.map(c => col(c.f).as(c.t))
-                dfPruned     = df.select(colsToSelect ++ colsRenamed: _*)
-              } yield dfPruned
-            )
+              } yield df
+          }(spark)
+
+        override def readAndProcess(basePath: String, partitionManager: PartitionManager): RIO[Logging, DataFrame] =
+          for {
+            df <- read(basePath, partitionManager)
+            colsToSelect = config.keepCols.map(col(_)) ++ PartitionManager.partitionColumns.map(col)
+            colsRenamed  = config.keepColsRenamed.map(c => col(c.f).as(c.t))
+            dfPruned     = df.select(colsToSelect ++ colsRenamed: _*)
+          } yield dfPruned
+
+        override def readAndProcess(partitionManager: PartitionManager): RIO[Logging, DataFrame] =
+          readAndProcess(readerConf.basePath, partitionManager)
       }
     )
 
-  def read(partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
-    RIO.accessM(_.get.read(partitionManager))
+  def readAndProcess(partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
+    RIO.accessM(_.get.readAndProcess(partitionManager))
 
+  def readAndProcess(basePath: String, partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
+    RIO.accessM(_.get.readAndProcess(basePath, partitionManager))
+
+  def read(basePath: String, partitionManager: PartitionManager): RIO[ReaderService with Logging, DataFrame] =
+    RIO.accessM(_.get.read(basePath, partitionManager))
 }

--- a/src/templates/bash-template
+++ b/src/templates/bash-template
@@ -37,6 +37,8 @@ do
     --duration)
       shift
       VARS="$VARS--duration $1 ";;
+    --delete)
+      VARS="$VARS--delete ";;
     --driver-memory)
       shift
       SPARKVARS="$SPARKVARS--driver-memory $1 ";;

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -11,6 +11,7 @@ reader {
 idManager {
   spark {
     dataPath = "/test/intermediate/base/path"
+    clearOnDelete = false
   }
   hbase {
     tableName = "IDManagement"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -33,6 +33,23 @@ janusgraph {
         }
       }
     ]
+    index {
+      composite = [
+        {
+          name = "objectIdIndex"
+          properties = ["objectId"]
+        }
+      ]
+      mixed = [
+      ]
+      edge = [
+        {
+          name = "similarityIndex"
+          properties = ["value"]
+          label = "similarity"
+        }
+      ]
+    }
   }
   vertexLoader {
     batchSize = 10

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -69,6 +69,11 @@ janusgraph {
     port: 8182
     tableName = "TestJanusGraph"
   }
+  indexBackend {
+    name = "elastic"
+    indexName = "elastictest"
+    host: "127.0.0.1:9200"
+  }
 }
 
 hbase {

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -20,7 +20,7 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
       test("PartitionManager will correctly generate read paths") {
         val dateString       = "2019-02-01"
         val date             = LocalDate.parse(dateString, dateFormat)
-        val partitionManager = PartitionManager(startDate = date, duration = 2)
+        val partitionManager = PaddedPartitionManager(startDate = date, duration = 2)
 
         assert(partitionManager.partitionPaths)(
           hasSameElements(List(PartitionPath("2019", "02", "01"), PartitionPath("2019", "02", "02")))
@@ -31,7 +31,7 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
         val path             = getClass.getResource(dataPath).getPath
         val dateString       = "2019-02-01"
         val date             = LocalDate.parse(dateString, dateFormat)
-        val partitionManager = PartitionManager(startDate = date, duration = 7)
+        val partitionManager = PaddedPartitionManager(startDate = date, duration = 7)
 
         val sparkLayer = SparkTestEnv.test
 

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -17,7 +17,16 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
 
   def spec: ZSpec[Environment, Failure] =
     suite("PartitionManagerSpec")(
-      test("PartitionManager will correctly generate read paths") {
+      test("PartitionManagerImpl will correctly generate read paths") {
+        val dateString       = "2019-02-01"
+        val date             = LocalDate.parse(dateString, dateFormat)
+        val partitionManager = PartitionManagerImpl(startDate = date, duration = 2)
+
+        assert(partitionManager.partitionPaths)(
+          hasSameElements(List(PartitionPath("2019", "2", "1"), PartitionPath("2019", "2", "2")))
+        )
+      },
+      test("PaddedPartitionManager will correctly generate read paths") {
         val dateString       = "2019-02-01"
         val date             = LocalDate.parse(dateString, dateFormat)
         val partitionManager = PaddedPartitionManager(startDate = date, duration = 2)
@@ -26,7 +35,7 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
           hasSameElements(List(PartitionPath("2019", "02", "01"), PartitionPath("2019", "02", "02")))
         )
       },
-      testM("PartitionManager will correctly filter out non-existing paths") {
+      testM("PaddedPartitionManager will correctly filter out non-existing paths") {
         val dataPath         = "/data"
         val path             = getClass.getResource(dataPath).getPath
         val dateString       = "2019-02-01"

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -14,8 +14,8 @@ import zio.test.environment.TestConsole
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
 import com.astrolabsoftware.grafink.models._
-import com.astrolabsoftware.grafink.services.IDManagerSparkService.IDManagerSparkService
 import com.astrolabsoftware.grafink.services.IDManagerSparkService
+import com.astrolabsoftware.grafink.services.IDManagerSparkService.IDManagerSparkService
 import com.astrolabsoftware.grafink.utils.{ SparkTestEnv, TempDirService }
 
 object PartitionManagerSpec extends DefaultRunnableSpec {
@@ -83,7 +83,8 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
             SchemaConfig(
               vertexPropertyCols = List("rfscore", "snnscore", "objectId"),
               vertexLabel = "type",
-              edgeLabels = List()
+              edgeLabels = List(),
+              index = IndexConfig(composite = List.empty, mixed = List.empty, edge = List.empty)
             ),
             VertexLoaderConfig(10),
             EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -88,7 +88,8 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
             ),
             VertexLoaderConfig(10),
             EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
-            JanusGraphStorageConfig("", 0, tableName = "test")
+            JanusGraphStorageConfig("", 0, tableName = "test"),
+            JanusGraphIndexBackendConfig("", "", "")
           )
 
         val idManagerConfig =

--- a/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/common/PartitionManagerSpec.scala
@@ -3,15 +3,20 @@ package com.astrolabsoftware.grafink.common
 import java.time.LocalDate
 
 import org.apache.hadoop.fs.FileSystem
-import zio.{ console, ZIO }
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{ IntegerType, StringType, StructField, StructType }
+import zio.{ console, ZIO, ZLayer }
 import zio.blocking.Blocking
 import zio.test._
 import zio.test.Assertion._
-import zio.test.environment.{ TestClock, TestConsole }
+import zio.test.environment.TestConsole
 
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
-import com.astrolabsoftware.grafink.utils.SparkTestEnv
+import com.astrolabsoftware.grafink.models._
+import com.astrolabsoftware.grafink.services.IDManagerSparkService.IDManagerSparkService
+import com.astrolabsoftware.grafink.services.IDManagerSparkService
+import com.astrolabsoftware.grafink.utils.{ SparkTestEnv, TempDirService }
 
 object PartitionManagerSpec extends DefaultRunnableSpec {
 
@@ -62,6 +67,76 @@ object PartitionManagerSpec extends DefaultRunnableSpec {
         assertM(app.provideLayer((Blocking.live >>> sparkLayer) ++ Logger.test))(
           hasSameElements(List(s"$path/year=2019/month=02/day=01"))
         )
+      },
+      testM("PartitionManager will correctly delete partitions") {
+        case class SampleData(payLoad: String, year: Int, month: Int, day: Int)
+
+        val dateString          = "2019-02-01"
+        val date                = LocalDate.parse(dateString, dateFormat)
+        val tempDirServiceLayer = ((zio.console.Console.live) >>> TempDirService.test)
+        val runtime             = zio.Runtime.default
+        val tempDir =
+          runtime.unsafeRun(TempDirService.createTempDir.provideLayer(tempDirServiceLayer ++ zio.console.Console.live))
+
+        val janusConfig =
+          JanusGraphConfig(
+            SchemaConfig(
+              vertexPropertyCols = List("rfscore", "snnscore", "objectId"),
+              vertexLabel = "type",
+              edgeLabels = List()
+            ),
+            VertexLoaderConfig(10),
+            EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
+            JanusGraphStorageConfig("", 0, tableName = "test")
+          )
+
+        val idManagerConfig =
+          IDManagerConfig(IDManagerSparkConfig(tempDir.getAbsolutePath, false), HBaseColumnConfig("", "", ""))
+
+        val idManagerConfigLayer = ZLayer.succeed(idManagerConfig)
+
+        // We are working with 4 days from date
+        val partitionManager = PartitionManagerImpl(date, 4)
+
+        val sampleSchema = StructType(
+          fields = Array(
+            StructField("payLoad", StringType),
+            StructField("year", IntegerType),
+            StructField("month", IntegerType),
+            StructField("day", IntegerType)
+          )
+        )
+        val app =
+          for {
+            spark <- SparkTestEnv.sparkEnv
+            df = spark.createDataFrame(
+              spark.sparkContext.parallelize(
+                List(
+                  Row("Some", 2019, 2, 1),
+                  Row("Some", 2019, 2, 3),
+                  Row("Some", 2019, 2, 5)
+                )
+              ),
+              sampleSchema
+            )
+            idManager <- ZIO.access[IDManagerSparkService](_.get)
+            // This will create the partitions and write the data
+            vertexData <- idManager.process(df, janusConfig.storage.tableName)
+            basePath = s"${idManagerConfig.spark.dataPath}/${janusConfig.storage.tableName}"
+            _             <- Utils.withFileSystem(fs => partitionManager.deletePartitions(basePath, fs))(df.sparkSession)
+            afterDeletion <- ZIO.effect(spark.read.parquet(basePath).drop("id").collect)
+            _             <- TempDirService.removeTempDir(tempDir)
+          } yield afterDeletion.toList
+
+        val logger     = Logger.test
+        val sparkLayer = SparkTestEnv.test
+        val idManagerLayer =
+          (logger ++ sparkLayer ++ ((tempDirServiceLayer ++ TestConsole.debug) >>> idManagerConfigLayer)) >>> IDManagerSparkService.live
+
+        val layer =
+          tempDirServiceLayer ++ TestConsole.debug ++ idManagerLayer ++ logger ++ sparkLayer
+        // Only data for 5th day is retained
+        assertM(app.provideLayer(layer))(hasSameElementsDistinct(List(Row("Some", 2019, 2, 5))))
       }
     )
 }

--- a/src/test/scala/com/astrolabsoftware/grafink/models/ConfigSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/models/ConfigSpec.scala
@@ -51,7 +51,12 @@ object ConfigSpec extends DefaultRunnableSpec {
               SchemaConfig(
                 vertexPropertyCols = List("rfscore", "snnscore"),
                 vertexLabel = "type",
-                edgeLabels = List(EdgeLabelConfig("similarity", Map("key" -> "value", "typ" -> "int")))
+                edgeLabels = List(EdgeLabelConfig("similarity", Map("key" -> "value", "typ" -> "int"))),
+                index = IndexConfig(
+                  composite = List(CompositeIndex(name = "objectIdIndex", properties = List("objectId"))),
+                  mixed = List.empty,
+                  edge = List(EdgeIndex(name = "similarityIndex", properties = List("value"), label = "similarity"))
+                )
               ),
               VertexLoaderConfig(10),
               EdgeLoaderConfig(100, 10, 25000, EdgeRulesConfig(SimilarityConfig("rfscore OR objectId"))),

--- a/src/test/scala/com/astrolabsoftware/grafink/models/ConfigSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/models/ConfigSpec.scala
@@ -60,7 +60,8 @@ object ConfigSpec extends DefaultRunnableSpec {
               ),
               VertexLoaderConfig(10),
               EdgeLoaderConfig(100, 10, 25000, EdgeRulesConfig(SimilarityConfig("rfscore OR objectId"))),
-              JanusGraphStorageConfig("127.0.0.1", 8182, tableName = "TestJanusGraph")
+              JanusGraphStorageConfig("127.0.0.1", 8182, tableName = "TestJanusGraph"),
+              JanusGraphIndexBackendConfig("elastic", "elastictest", "127.0.0.1:9200")
             )
           )
         )

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/EdgeProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/EdgeProcessorSpec.scala
@@ -12,7 +12,6 @@ import zio.test.{ DefaultRunnableSpec, _ }
 import zio.test.Assertion._
 import zio.test.environment.TestConsole
 
-import com.astrolabsoftware.grafink.Job.JobTime
 import com.astrolabsoftware.grafink.common.PaddedPartitionManager
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
@@ -43,7 +42,8 @@ object EdgeProcessorSpec extends DefaultRunnableSpec {
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(10, parallelismConfig, taskSize, EdgeRulesConfig(similarityConfig)),
-          JanusGraphStorageConfig("", 0, tableName = "test")
+          JanusGraphStorageConfig("", 0, tableName = "test"),
+          JanusGraphIndexBackendConfig("", "", "")
         )
       val parallelism1 = EdgeProcessorLive(janusConfig).getParallelism(3000).partitions
       val parallelism2 = EdgeProcessorLive(janusConfig).getParallelism(300000).partitions
@@ -77,10 +77,9 @@ object EdgeProcessorSpec extends DefaultRunnableSpec {
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(similarityConfig)),
-          JanusGraphStorageConfig("", 0, tableName = "test")
+          JanusGraphStorageConfig("", 0, tableName = "test"),
+          JanusGraphIndexBackendConfig("", "", "")
         )
-
-      val jobTime = JobTime(date, 1)
 
       val tempDirServiceLayer = ((zio.console.Console.live) >>> TempDirService.test)
       val runtime             = zio.Runtime.default

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/EdgeProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/EdgeProcessorSpec.scala
@@ -38,7 +38,8 @@ object EdgeProcessorSpec extends DefaultRunnableSpec {
           SchemaConfig(
             vertexPropertyCols = List("rfscore", "snnscore", "objectId"),
             vertexLabel = "type",
-            edgeLabels = List(EdgeLabelConfig(name = edgeLabel, Map("value" -> "long")))
+            edgeLabels = List(EdgeLabelConfig(name = edgeLabel, Map("value" -> "long"))),
+            index = IndexConfig(composite = List.empty, mixed = List.empty, edge = List.empty)
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(10, parallelismConfig, taskSize, EdgeRulesConfig(similarityConfig)),
@@ -67,7 +68,12 @@ object EdgeProcessorSpec extends DefaultRunnableSpec {
           SchemaConfig(
             vertexPropertyCols = List("rfscore", "snnscore", "objectId"),
             vertexLabel = "type",
-            edgeLabels = List(EdgeLabelConfig(name = edgeLabel, Map("value" -> "long")))
+            edgeLabels = List(EdgeLabelConfig(name = edgeLabel, Map("value" -> "long"))),
+            index = IndexConfig(
+              composite = List.empty,
+              mixed = List.empty,
+              edge = List(EdgeIndex(name = "similarityIndex", properties = List("value"), label = edgeLabel))
+            )
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(similarityConfig)),

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
@@ -4,13 +4,18 @@ import java.time.LocalDate
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.{ DoubleType, LongType, StringType, StructField, StructType }
+import org.apache.tinkerpop.gremlin.structure.T
+import org.janusgraph.graphdb.database.StandardJanusGraph
 import zio.{ ZIO, ZLayer }
 import zio.test.{ DefaultRunnableSpec, _ }
 import zio.test.Assertion._
 import zio.test.environment.TestConsole
 
 import com.astrolabsoftware.grafink.Job.JobTime
-import com.astrolabsoftware.grafink.common.PaddedPartitionManager
+import com.astrolabsoftware.grafink.common.{ PaddedPartitionManager, Utils }
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
 import com.astrolabsoftware.grafink.models._
@@ -45,8 +50,6 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
           JanusGraphStorageConfig("", 0, tableName = "test")
         )
-
-      val jobTime = JobTime(date, 1)
 
       val tempDirServiceLayer = ((zio.console.Console.live) >>> TempDirService.test)
       val runtime             = zio.Runtime.default
@@ -86,6 +89,75 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
       assertM(app.provideLayer(layer))(
         hasSameElementsDistinct(List("ZTF19acmcetc", "ZTF17aaanypg", "ZTF19acmbxka", "ZTF19acmbxfe", "ZTF19acmbtac"))
       )
+    },
+    testM("VertexProcessor will correctly delete already added input alerts into janusgraph") {
+      val dateString = "2019-02-01"
+      val date       = LocalDate.parse(dateString, dateFormat)
+      val dataPath   = "/data"
+      val path       = getClass.getResource(dataPath).getPath
+      val logger     = Logger.test
+
+      val janusConfig =
+        JanusGraphConfig(
+          SchemaConfig(
+            vertexPropertyCols = List("rfscore", "objectId"),
+            vertexLabel = "type",
+            edgeLabels = List()
+          ),
+          VertexLoaderConfig(1),
+          EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
+          JanusGraphStorageConfig("", 0, tableName = "test")
+        )
+
+      val vertexSchema = StructType(
+        fields = Array(
+          StructField("id", LongType, false),
+          StructField("objectId", StringType, false),
+          StructField("rfscore", DoubleType, false)
+        )
+      )
+
+      val schemaMap = vertexSchema.map(f => f.name -> f.dataType).toMap
+
+      val verticesList = List(
+        new GenericRowWithSchema(Array(1L, "objectid1", 0.345), vertexSchema),
+        new GenericRowWithSchema(Array(2L, "objectid2", 0.9987), vertexSchema),
+        new GenericRowWithSchema(Array(3L, "objectid3", 0.0), vertexSchema)
+      )
+      // Delete only first 2 vertices
+      val verticesToDelete = verticesList.dropRight(1).toIterator
+
+      @inline
+      def getVertexProperties(r: Row): Seq[AnyRef] =
+        List("objectId", "rfscore").flatMap { property =>
+          val dType = Utils.getClassTag(schemaMap(property))
+          List(property, r.getAs[dType.type](property))
+        }
+
+      def getVertexParams(r: Row, id: java.lang.Long): Seq[AnyRef] = Seq(T.id, id) ++ getVertexProperties(r)
+
+      val app = for {
+        output <- JanusGraphTestEnv
+          .test(janusConfig)
+          .use {
+            graph =>
+              val idMgr = graph.asInstanceOf[StandardJanusGraph].getIDManager
+              val vertexParams = verticesList.map(vertex =>
+                getVertexParams(vertex, java.lang.Long.valueOf(idMgr.toVertexId(vertex.getAs[Long]("id"))))
+              )
+              for {
+                _ <- ZIO.effect(vertexParams.foreach(v => graph.addVertex(v: _*)))
+                _ <- ZIO.effect(graph.tx.commit())
+                vertexProcessorLive = VertexProcessorLive(janusConfig)
+                _ <- vertexProcessorLive.deleteJob(graph, verticesToDelete)
+              } yield graph.traversal().V().count().toList.asScala.toList.head
+          }
+      } yield output
+
+      val vertexProcessorLayer = (sparkLayer ++ ZLayer.succeed(janusConfig) ++ logger) >>> VertexProcessor.live
+      val layer                = TestConsole.debug ++ vertexProcessorLayer ++ logger ++ sparkLayer
+
+      assertM(app.provideLayer(layer))(equalTo(java.lang.Long.valueOf(1L)))
     }
   )
 }

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
@@ -75,6 +75,7 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
               _ <- vertexProcessorLive
                 .job(janusConfig, graph, dataTypeForVertexPropertyCols, vertexData.current.collect.toIterator)
               g = graph.traversal()
+              _ <- TempDirService.removeTempDir(tempDir)
             } yield g.V().toList.asScala.map(_.property("objectId").value().toString).toList
           )
       } yield output

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
@@ -30,11 +30,12 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
 
   def spec: ZSpec[Environment, Failure] = suite("VertexProcessorSpec")(
     testM("VertexProcessor will correctly add input alerts into janusgraph") {
-      val dateString = "2019-02-01"
-      val date       = LocalDate.parse(dateString, dateFormat)
-      val dataPath   = "/data"
-      val path       = getClass.getResource(dataPath).getPath
-      val logger     = Logger.test
+      val dateString    = "2019-02-01"
+      val date          = LocalDate.parse(dateString, dateFormat)
+      val dataPath      = "/data"
+      val path          = getClass.getResource(dataPath).getPath
+      val logger        = Logger.test
+      val objectIdIndex = "objectIdIndex"
       val readerConfig =
         ZLayer.succeed(
           ReaderConfig(path, Parquet, keepCols = List("rfscore", "snnscore", "objectId"), keepColsRenamed = List())
@@ -44,7 +45,12 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
           SchemaConfig(
             vertexPropertyCols = List("rfscore", "snnscore", "objectId"),
             vertexLabel = "type",
-            edgeLabels = List()
+            edgeLabels = List(),
+            IndexConfig(
+              composite = List(CompositeIndex(name = objectIdIndex, properties = List("objectId"))),
+              mixed = List.empty,
+              edge = List.empty
+            )
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
@@ -103,7 +109,8 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
           SchemaConfig(
             vertexPropertyCols = List("rfscore", "objectId"),
             vertexLabel = "type",
-            edgeLabels = List()
+            edgeLabels = List(),
+            index = IndexConfig(composite = List.empty, mixed = List.empty, edge = List.empty)
           ),
           VertexLoaderConfig(1),
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),

--- a/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/processor/VertexProcessorSpec.scala
@@ -14,7 +14,6 @@ import zio.test.{ DefaultRunnableSpec, _ }
 import zio.test.Assertion._
 import zio.test.environment.TestConsole
 
-import com.astrolabsoftware.grafink.Job.JobTime
 import com.astrolabsoftware.grafink.common.{ PaddedPartitionManager, Utils }
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
@@ -54,7 +53,8 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
-          JanusGraphStorageConfig("", 0, tableName = "test")
+          JanusGraphStorageConfig("", 0, tableName = "test"),
+          JanusGraphIndexBackendConfig("", "", "")
         )
 
       val tempDirServiceLayer = ((zio.console.Console.live) >>> TempDirService.test)
@@ -114,7 +114,8 @@ object VertexProcessorSpec extends DefaultRunnableSpec {
           ),
           VertexLoaderConfig(1),
           EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
-          JanusGraphStorageConfig("", 0, tableName = "test")
+          JanusGraphStorageConfig("", 0, tableName = "test"),
+          JanusGraphIndexBackendConfig("", "", "")
         )
 
       val vertexSchema = StructType(

--- a/src/test/scala/com/astrolabsoftware/grafink/reader/ReaderSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/reader/ReaderSpec.scala
@@ -6,7 +6,7 @@ import zio._
 import zio.test._
 import zio.test.Assertion._
 
-import com.astrolabsoftware.grafink.common.PartitionManager
+import com.astrolabsoftware.grafink.common.PaddedPartitionManager
 import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.logging.Logger
 import com.astrolabsoftware.grafink.models.{ Parquet, ReaderConfig }
@@ -28,7 +28,7 @@ object ReaderSpec extends DefaultRunnableSpec {
 
       val app =
         for {
-          df <- Reader.read(PartitionManager(date, 1))
+          df <- Reader.readAndProcess(PaddedPartitionManager(date, 1))
         } yield df.count
 
       val layer = ((logger ++ config ++ sparkLayer) >>> Reader.live) ++ logger

--- a/src/test/scala/com/astrolabsoftware/grafink/schema/SchemaLoaderSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/schema/SchemaLoaderSpec.scala
@@ -17,6 +17,7 @@ import com.astrolabsoftware.grafink.models.{
   EdgeRulesConfig,
   IndexConfig,
   JanusGraphConfig,
+  JanusGraphIndexBackendConfig,
   JanusGraphStorageConfig,
   SchemaConfig,
   SimilarityConfig,
@@ -48,7 +49,8 @@ object SchemaLoaderSpec extends DefaultRunnableSpec {
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(100, 10, 25000, EdgeRulesConfig(SimilarityConfig("rfscore"))),
-          JanusGraphStorageConfig("127.0.0.1", 8182, tableName = "TestJanusGraph")
+          JanusGraphStorageConfig("127.0.0.1", 8182, tableName = "TestJanusGraph"),
+          JanusGraphIndexBackendConfig("", "", "")
         )
 
       val app =
@@ -95,7 +97,8 @@ object SchemaLoaderSpec extends DefaultRunnableSpec {
           ),
           VertexLoaderConfig(10),
           EdgeLoaderConfig(100, 10, 25000, EdgeRulesConfig(SimilarityConfig("rfscore"))),
-          JanusGraphStorageConfig("127.0.0.1", 8182, tableName = "TestJanusGraph")
+          JanusGraphStorageConfig("127.0.0.1", 8182, tableName = "TestJanusGraph"),
+          JanusGraphIndexBackendConfig("", "", "")
         )
 
       case class IndexResult(name: String, status: SchemaStatus)

--- a/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
@@ -38,7 +38,8 @@ object IDManagerSpec extends DefaultRunnableSpec {
             ),
             VertexLoaderConfig(10),
             EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
-            JanusGraphStorageConfig("", 0, janusGraphTableName)
+            JanusGraphStorageConfig("", 0, janusGraphTableName),
+            JanusGraphIndexBackendConfig("", "", "")
           )
         )
       val mockEnv: ULayer[HBaseClientService] = (

--- a/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
@@ -13,18 +13,7 @@ import com.astrolabsoftware.grafink.common.PartitionManager.dateFormat
 import com.astrolabsoftware.grafink.hbase.HBaseClientService.HBaseClientService
 import com.astrolabsoftware.grafink.hbase.HBaseClientServiceMock
 import com.astrolabsoftware.grafink.logging.Logger
-import com.astrolabsoftware.grafink.models.{
-  EdgeLoaderConfig,
-  EdgeRulesConfig,
-  HBaseColumnConfig,
-  IDManagerConfig,
-  JanusGraphConfig,
-  JanusGraphStorageConfig,
-  SchemaConfig,
-  SimilarityConfig,
-  SparkPathConfig,
-  VertexLoaderConfig
-}
+import com.astrolabsoftware.grafink.models._
 
 object IDManagerSpec extends DefaultRunnableSpec {
 
@@ -36,7 +25,8 @@ object IDManagerSpec extends DefaultRunnableSpec {
       val id                  = 1234L
       val jobTime             = JobTime(LocalDate.parse(date, dateFormat), 1)
       val app                 = IDManager.fetchID(jobTime)
-      val idConfigLayer       = ZLayer.succeed(IDManagerConfig(SparkPathConfig(""), HBaseColumnConfig("", "", "")))
+      val idConfigLayer =
+        ZLayer.succeed(IDManagerConfig(IDManagerSparkConfig("", false), HBaseColumnConfig("", "", "")))
       val janusConfigLayer =
         ZLayer.succeed(
           JanusGraphConfig(

--- a/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
+++ b/src/test/scala/com/astrolabsoftware/grafink/services/IDManagerSpec.scala
@@ -30,7 +30,12 @@ object IDManagerSpec extends DefaultRunnableSpec {
       val janusConfigLayer =
         ZLayer.succeed(
           JanusGraphConfig(
-            SchemaConfig(List(""), "", List()),
+            SchemaConfig(
+              List(""),
+              "",
+              List(),
+              IndexConfig(composite = List.empty, mixed = List.empty, edge = List.empty)
+            ),
             VertexLoaderConfig(10),
             EdgeLoaderConfig(10, 1, 25000, EdgeRulesConfig(SimilarityConfig(""))),
             JanusGraphStorageConfig("", 0, janusGraphTableName)


### PR DESCRIPTION

- This PR addresses #11 by adding a CL parameter --delete that runs Grafink in delete mode and deletes the data for the startDate and duration. Also there is a configurable option to remove IDManager data on successful data deletion from the graph.

- This PR also addresses #13 by adding support for all 3 types of indices supported by JanusGraph: Composite, Mixed and Vertex-Centric